### PR TITLE
Add curated library bookshelf experience

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -3,6 +3,7 @@
 - Keep contributor guidance in sync across [AGENTS.md](../AGENTS.md), this file, and the README whenever project rules or workflows change.
 - Update documentation in the same pull request as any behavior, tooling, workflow, or schema change. Add or extend docs under `docs/` when a README update alone is not enough.
 - Use CSS custom properties for color values. Define palette values in `src/lib/main.css` and reference them with `var(--color-...)` instead of hardcoding color literals in component styles.
+- Prefer CSS modules for component-scoped styles instead of inline `<style>` blocks in `.svelte` files. Keep shared tokens and global styles in `src/lib/main.css`, and colocate component styles in `*.module.css` files.
 - For Contentful model changes, update both `contentful/migrations/` and the application code that consumes the model in `src/lib/services/**` and related UI.
 - Keep the OSS quality pipeline healthy. Changes that affect linting, formatting, tests, static analysis, or security checks must update the relevant scripts, workflows, and docs together.
 - Do not remove or weaken validation, contributor rules, or documentation requirements without updating both agent instruction files and explaining the change in the README or docs.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,6 @@
 <INSTRUCTIONS>
 - Always use CSS custom properties for color values; do not hardcode hex/rgb/rgba color literals in component styles. Define the palette in `src/lib/main.css` and reference it via `var(--color-...)`.
+- Prefer CSS modules for component-specific styling instead of inline `<style>` blocks in `.svelte` files. Keep shared tokens and global styles in `src/lib/main.css`, and colocate component styles in `*.module.css` files.
 </INSTRUCTIONS>
 # Repository agent instructions
 

--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ The repository uses an open-source-only quality pipeline for formatting, linting
 - **SvelteKit app shell**: `+layout.svelte` renders `Header`, `Nav`, page content, and footer.
 - **Service layer**: navigation/page clients are abstracted behind small interfaces in `src/lib/services/**`.
 - **Content source**: Contentful is the backing CMS for page content and nav links.
+- **Library route**: `src/routes/library/+page.svelte` renders a curated bookshelf-style library from local seed data in `src/lib/services/library/library.ts`.
 - **Component library**: atoms/molecules/organisms live in `src/lib/**` with Storybook stories and docs.
 - **Cloudflare target**: adapter is `@sveltejs/adapter-cloudflare` and Worker config is in `wrangler.toml`.
 

--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ SvelteKit-powered personal site that renders pages from Contentful and deploys t
 
 The repository uses an open-source-only quality pipeline for formatting, linting, type checking, dependency hygiene, tests, and security scanning. When a PR changes behavior, tooling, workflows, or contributor rules, update `README.md`, `AGENTS.md`, `.github/copilot-instructions.md`, and any relevant docs in the same change.
 
+Component-scoped styles should live in colocated `*.module.css` files rather than inline `<style>` blocks inside `.svelte` components. Keep shared design tokens and global styles in `src/lib/main.css`, and continue using CSS custom properties for color values.
+
 ## How this repository works
 
 ### Runtime flow

--- a/docs/library-bookshelf-experience.md
+++ b/docs/library-bookshelf-experience.md
@@ -4,9 +4,9 @@
 
 ## Layout
 
-- Hero panel: introduces the Library with a short framing statement and three summary stats for books, articles, and topics.
-- Filter panel: exposes content-type toggles plus a topic control row that both apply across the same collection.
-- Reading grid: books and articles appear together in one card layout rather than split into separate shelves.
+- Hero section: introduces the Library with a short framing statement and three summary stats for books, articles, and topics.
+- Filter row: exposes content-type toggles plus a topic control row that both apply across the same collection.
+- Reading grid: books and articles appear together in one editorial card layout rather than split into separate shelves.
 
 ## Filtering Interaction
 
@@ -19,7 +19,8 @@
 ## Visual Direction
 
 - Use warm paper and timber tokens from [`src/lib/main.css`](../src/lib/main.css) to create the bookshelf feel.
-- Keep cards editorial and tactile without decorative left-edge color flashes or shelf rails. The distinction between books and articles should come from the top-right icon and type label instead.
+- Keep the layout open and aligned with the rest of the site: rely on spacing, rules, and typography more than boxed panels or heavily rounded containers.
+- Keep cards editorial and tactile without decorative left-edge color flashes, shelf rails, or circular icon badges. The distinction between books and articles should come from the Lucide icon and type label instead.
 - Preserve the site's existing typography so the new page feels like part of the same system instead of a separate microsite.
 
 ## Responsive Behavior

--- a/docs/library-bookshelf-experience.md
+++ b/docs/library-bookshelf-experience.md
@@ -1,32 +1,32 @@
 # Library Bookshelf Experience
 
-`/library` is a curated destination page for books and articles. It is intentionally editorial rather than archive-like, with topic filters that rebalance the whole page while keeping books and articles separated into their own shelves.
+`/library` is a curated destination page for books and articles. It is intentionally editorial rather than archive-like, with one shared reading grid that can be narrowed by topic and by content type.
 
 ## Layout
 
 - Hero panel: introduces the Library with a short framing statement and three summary stats for books, articles, and topics.
-- Filter panel: exposes a single topic control row that applies across the entire collection.
-- Books shelf: longer-form references that inform leadership, delivery, and systems thinking.
-- Articles shelf: shorter essays and field notes for practical application.
+- Filter panel: exposes content-type toggles plus a topic control row that both apply across the same collection.
+- Reading grid: books and articles appear together in one card layout rather than split into separate shelves.
 
 ## Filtering Interaction
 
-- `All topics` is the default state.
-- Selecting a topic filters both shelves at the same time.
-- Filter state stays lightweight on purpose: there is only one active topic at a time, which keeps the experience feeling curated instead of becoming a faceted search UI.
-- The summary copy under the filter heading updates to reflect the current split between books and articles.
+- `All topics` is the default topic state.
+- `Books` and `Articles` are both active by default, so the mixed collection stays visible unless one is toggled off.
+- Selecting a topic filters the whole collection at the same time.
+- Type filters are independent toggles, but at least one stays active so the page never collapses accidentally.
+- The summary copy under the filter heading updates to reflect the current count and type mix.
 
 ## Visual Direction
 
 - Use warm paper and timber tokens from [`src/lib/main.css`](../src/lib/main.css) to create the bookshelf feel.
-- Keep cards editorial and tactile: accent spines, rounded covers, and shelf rails do more of the work than heavy decoration.
-- Preserve the site’s existing typography so the new page feels like part of the same system instead of a separate microsite.
+- Keep cards editorial and tactile without decorative left-edge color flashes or shelf rails. The distinction between books and articles should come from the top-right icon and type label instead.
+- Preserve the site's existing typography so the new page feels like part of the same system instead of a separate microsite.
 
 ## Responsive Behavior
 
-- Mobile: the hero stacks vertically, filter chips wrap naturally, and each shelf renders as a single column above the shelf rail.
-- Tablet and up: the stat cards move into a three-column row and shelf cards expand into a two-column grid.
-- Topic filters remain visible near the top of the page so the core interaction stays reachable after the hero.
+- Mobile: the hero stacks vertically, filter chips wrap naturally, and the reading grid renders as a single column.
+- Tablet and up: the stat cards move into a three-column row and the reading grid expands to two and then three columns.
+- Topic and type filters remain visible near the top of the page so the core interaction stays reachable after the hero.
 
 ## Content Source
 

--- a/docs/library-bookshelf-experience.md
+++ b/docs/library-bookshelf-experience.md
@@ -1,0 +1,34 @@
+# Library Bookshelf Experience
+
+`/library` is a curated destination page for books and articles. It is intentionally editorial rather than archive-like, with topic filters that rebalance the whole page while keeping books and articles separated into their own shelves.
+
+## Layout
+
+- Hero panel: introduces the Library with a short framing statement and three summary stats for books, articles, and topics.
+- Filter panel: exposes a single topic control row that applies across the entire collection.
+- Books shelf: longer-form references that inform leadership, delivery, and systems thinking.
+- Articles shelf: shorter essays and field notes for practical application.
+
+## Filtering Interaction
+
+- `All topics` is the default state.
+- Selecting a topic filters both shelves at the same time.
+- Filter state stays lightweight on purpose: there is only one active topic at a time, which keeps the experience feeling curated instead of becoming a faceted search UI.
+- The summary copy under the filter heading updates to reflect the current split between books and articles.
+
+## Visual Direction
+
+- Use warm paper and timber tokens from [`src/lib/main.css`](/C:/Users/chris/.codex/worktrees/f179/cipowell-svelte/src/lib/main.css) to create the bookshelf feel.
+- Keep cards editorial and tactile: accent spines, rounded covers, and shelf rails do more of the work than heavy decoration.
+- Preserve the site’s existing typography so the new page feels like part of the same system instead of a separate microsite.
+
+## Responsive Behavior
+
+- Mobile: the hero stacks vertically, filter chips wrap naturally, and each shelf renders as a single column above the shelf rail.
+- Tablet and up: the stat cards move into a three-column row and shelf cards expand into a two-column grid.
+- Topic filters remain visible near the top of the page so the core interaction stays reachable after the hero.
+
+## Content Source
+
+- The initial version is seeded from [`src/lib/services/library/library.ts`](/C:/Users/chris/.codex/worktrees/f179/cipowell-svelte/src/lib/services/library/library.ts).
+- This avoids introducing a Contentful model before the information architecture is settled, while still giving later CMS work a concrete UI target.

--- a/docs/library-bookshelf-experience.md
+++ b/docs/library-bookshelf-experience.md
@@ -18,7 +18,7 @@
 
 ## Visual Direction
 
-- Use warm paper and timber tokens from [`src/lib/main.css`](/C:/Users/chris/.codex/worktrees/f179/cipowell-svelte/src/lib/main.css) to create the bookshelf feel.
+- Use warm paper and timber tokens from [`src/lib/main.css`](../src/lib/main.css) to create the bookshelf feel.
 - Keep cards editorial and tactile: accent spines, rounded covers, and shelf rails do more of the work than heavy decoration.
 - Preserve the site’s existing typography so the new page feels like part of the same system instead of a separate microsite.
 
@@ -30,5 +30,5 @@
 
 ## Content Source
 
-- The initial version is seeded from [`src/lib/services/library/library.ts`](/C:/Users/chris/.codex/worktrees/f179/cipowell-svelte/src/lib/services/library/library.ts).
+- The initial version is seeded from [`src/lib/services/library/library.ts`](../src/lib/services/library/library.ts).
 - This avoids introducing a Contentful model before the information architecture is settled, while still giving later CMS work a concrete UI target.

--- a/docs/library-bookshelf-experience.md
+++ b/docs/library-bookshelf-experience.md
@@ -19,6 +19,7 @@
 ## Visual Direction
 
 - Use warm paper and timber tokens from [`src/lib/main.css`](../src/lib/main.css) to create the bookshelf feel.
+- Keep shared site tokens intact; route-specific background shifts for `/library` should be applied in the library CSS module rather than by changing the global `--color-background` token.
 - Keep the layout open and aligned with the rest of the site: rely on spacing, rules, and typography more than boxed panels or heavily rounded containers.
 - Keep cards editorial and tactile without decorative left-edge color flashes, shelf rails, or circular icon badges. The distinction between books and articles should come from the Lucide icon and type label instead.
 - Preserve the site's existing typography so the new page feels like part of the same system instead of a separate microsite.

--- a/src/lib/main.css
+++ b/src/lib/main.css
@@ -96,25 +96,20 @@
 	--color-library-filter-text-active: var(--color-white);
 	--color-library-stat-surface: #fff7ee;
 	--color-library-stat-border: #ddccb8;
-	--color-library-shelf-backdrop: #efe5d6;
-	--color-library-shelf-rail-top: #c69a6b;
-	--color-library-shelf-rail-bottom: #9a6f45;
 	--color-library-card-surface: #fffdf9;
 	--color-library-card-border: #d9c8b4;
 	--color-library-card-meta: #6c5742;
 	--color-library-chip-surface: #efe3d2;
 	--color-library-chip-text: #644a2f;
+	--color-library-icon-surface: #f4eadc;
+	--color-library-icon-border: #d7c4ae;
+	--color-library-icon: #5a442f;
 	--color-library-topic-surface: #f6eee2;
 	--color-library-topic-text: #664d34;
 	--color-library-empty-surface: #fff8ef;
 	--color-library-empty-border: #dbcab5;
-	--color-library-accent-amber: #c58a32;
-	--color-library-accent-sage: #718a5a;
-	--color-library-accent-ink: #4c5f84;
-	--color-library-accent-rose: #a16467;
 	--elevation-library-card: 0 20px 32px -26px rgba(72, 46, 19, 0.45);
 	--elevation-library-panel: 0 22px 44px -34px rgba(72, 46, 19, 0.32);
-	--elevation-library-rail: 0 16px 28px -24px rgba(72, 46, 19, 0.55);
 }
 
 html {

--- a/src/lib/main.css
+++ b/src/lib/main.css
@@ -1,5 +1,5 @@
 :root {
-	--color-background: var(--color-white);
+	--color-background: #f5f3f7;
 	--color-text-primary: #2a2a2a;
 	--color-accent-1: #4b1d6b;
 	--color-text-on-accent: #f5f3f7;

--- a/src/lib/main.css
+++ b/src/lib/main.css
@@ -82,6 +82,39 @@
 	--color-nav-menu-bg: var(--color-white);
 	--color-nav-menu-border: var(--color-divider-default);
 	--elevation-nav-menu: 0 6px 20px rgba(42, 42, 42, 0.1);
+
+	--color-library-hero-surface: #f8f1e5;
+	--color-library-hero-border: #d9c8b4;
+	--color-library-panel-surface: #fffaf2;
+	--color-library-panel-border: #e1d3c2;
+	--color-library-panel-muted: #7a6650;
+	--color-library-filter-surface: var(--color-white);
+	--color-library-filter-surface-hover: #f4ede3;
+	--color-library-filter-surface-active: #5e3a1b;
+	--color-library-filter-border: #cdb9a1;
+	--color-library-filter-border-active: #5e3a1b;
+	--color-library-filter-text-active: var(--color-white);
+	--color-library-stat-surface: #fff7ee;
+	--color-library-stat-border: #ddccb8;
+	--color-library-shelf-backdrop: #efe5d6;
+	--color-library-shelf-rail-top: #c69a6b;
+	--color-library-shelf-rail-bottom: #9a6f45;
+	--color-library-card-surface: #fffdf9;
+	--color-library-card-border: #d9c8b4;
+	--color-library-card-meta: #6c5742;
+	--color-library-chip-surface: #efe3d2;
+	--color-library-chip-text: #644a2f;
+	--color-library-topic-surface: #f6eee2;
+	--color-library-topic-text: #664d34;
+	--color-library-empty-surface: #fff8ef;
+	--color-library-empty-border: #dbcab5;
+	--color-library-accent-amber: #c58a32;
+	--color-library-accent-sage: #718a5a;
+	--color-library-accent-ink: #4c5f84;
+	--color-library-accent-rose: #a16467;
+	--elevation-library-card: 0 20px 32px -26px rgba(72, 46, 19, 0.45);
+	--elevation-library-panel: 0 22px 44px -34px rgba(72, 46, 19, 0.32);
+	--elevation-library-rail: 0 16px 28px -24px rgba(72, 46, 19, 0.55);
 }
 
 html {

--- a/src/lib/main.css
+++ b/src/lib/main.css
@@ -83,33 +83,20 @@
 	--color-nav-menu-border: var(--color-divider-default);
 	--elevation-nav-menu: 0 6px 20px rgba(42, 42, 42, 0.1);
 
-	--color-library-hero-surface: #f8f1e5;
-	--color-library-hero-border: #d9c8b4;
-	--color-library-panel-surface: #fffaf2;
-	--color-library-panel-border: #e1d3c2;
 	--color-library-panel-muted: #7a6650;
-	--color-library-filter-surface: var(--color-white);
-	--color-library-filter-surface-hover: #f4ede3;
-	--color-library-filter-surface-active: #5e3a1b;
-	--color-library-filter-border: #cdb9a1;
-	--color-library-filter-border-active: #5e3a1b;
-	--color-library-filter-text-active: var(--color-white);
-	--color-library-stat-surface: #fff7ee;
-	--color-library-stat-border: #ddccb8;
-	--color-library-card-surface: #fffdf9;
-	--color-library-card-border: #d9c8b4;
+	--color-library-rule: #dccdbd;
+	--color-library-card-border: #dccdbd;
+	--color-library-card-border-strong: #b89c7d;
 	--color-library-card-meta: #6c5742;
-	--color-library-chip-surface: #efe3d2;
-	--color-library-chip-text: #644a2f;
-	--color-library-icon-surface: #f4eadc;
-	--color-library-icon-border: #d7c4ae;
+	--color-library-type-label: #644a2f;
 	--color-library-icon: #5a442f;
-	--color-library-topic-surface: #f6eee2;
 	--color-library-topic-text: #664d34;
-	--color-library-empty-surface: #fff8ef;
-	--color-library-empty-border: #dbcab5;
-	--elevation-library-card: 0 20px 32px -26px rgba(72, 46, 19, 0.45);
-	--elevation-library-panel: 0 22px 44px -34px rgba(72, 46, 19, 0.32);
+	--color-library-topic-marker: #c7b39b;
+	--color-library-filter-text: #765f49;
+	--color-library-filter-text-active: #2a2a2a;
+	--color-library-filter-rule: #d9cbbd;
+	--color-library-filter-rule-strong: #b89c7d;
+	--color-library-filter-rule-active: #5e3a1b;
 }
 
 html {

--- a/src/lib/main.css
+++ b/src/lib/main.css
@@ -1,5 +1,5 @@
 :root {
-	--color-background: #f5f3f7;
+	--color-background: var(--color-white);
 	--color-text-primary: #2a2a2a;
 	--color-accent-1: #4b1d6b;
 	--color-text-on-accent: #f5f3f7;

--- a/src/lib/organisms/library_experience/LibraryExperience.module.css
+++ b/src/lib/organisms/library_experience/LibraryExperience.module.css
@@ -4,7 +4,7 @@
 
 .layout {
 	display: grid;
-	gap: var(--space-4);
+	gap: var(--space-5);
 }
 
 .hero,
@@ -12,11 +12,7 @@
 .empty {
 	display: grid;
 	gap: var(--space-3);
-	padding: var(--space-4);
-	border: 1px solid var(--color-library-hero-border);
-	border-radius: 1.5rem;
-	background: var(--color-library-hero-surface);
-	box-shadow: var(--elevation-library-panel);
+	padding-block: 0;
 }
 
 .heroCopy,
@@ -31,7 +27,7 @@
 	font-weight: var(--font-weight-semibold);
 	letter-spacing: 0.12em;
 	text-transform: uppercase;
-	color: var(--color-library-chip-text);
+	color: var(--color-library-type-label);
 }
 
 .intro,
@@ -47,16 +43,14 @@
 .stats {
 	display: grid;
 	grid-template-columns: repeat(1, minmax(0, 1fr));
-	gap: var(--space-2);
+	gap: var(--space-3);
 }
 
 .stat {
 	display: grid;
-	gap: 0.35rem;
-	padding: var(--space-3);
-	border: 1px solid var(--color-library-stat-border);
-	border-radius: 1rem;
-	background: var(--color-library-stat-surface);
+	gap: 0.2rem;
+	padding-top: var(--space-2);
+	border-top: 1px solid var(--color-library-rule);
 }
 
 .statValue {
@@ -91,27 +85,28 @@
 }
 
 .filter {
-	padding: 0.75rem 1rem;
-	border: 1px solid var(--color-library-filter-border);
-	border-radius: 999px;
-	background: var(--color-library-filter-surface);
-	color: var(--color-text-primary);
+	padding: 0 0 0.35rem;
+	border: none;
+	border-bottom: 1px solid var(--color-library-filter-rule);
+	background: transparent;
+	color: var(--color-library-filter-text);
 	font: inherit;
+	font-weight: var(--font-weight-medium);
 	cursor: pointer;
 }
 
 .filter:hover {
-	background: var(--color-library-filter-surface-hover);
+	color: var(--color-text-primary);
+	border-bottom-color: var(--color-library-filter-rule-strong);
 }
 
 .filter:focus-visible {
 	outline: 3px solid var(--color-focus-ring);
-	outline-offset: 3px;
+	outline-offset: 4px;
 }
 
 .filterActive {
-	border-color: var(--color-library-filter-border-active);
-	background: var(--color-library-filter-surface-active);
+	border-bottom-color: var(--color-library-filter-rule-active);
 	color: var(--color-library-filter-text-active);
 }
 
@@ -123,6 +118,8 @@
 .collectionHeader {
 	display: grid;
 	gap: var(--space-1);
+	padding-bottom: var(--space-2);
+	border-bottom: 1px solid var(--color-library-rule);
 }
 
 .collectionHeader h2 {
@@ -130,8 +127,8 @@
 }
 
 .empty {
-	background: var(--color-library-empty-surface);
-	border-color: var(--color-library-empty-border);
+	padding-top: var(--space-2);
+	border-top: 1px solid var(--color-library-rule);
 }
 
 .empty h2 {
@@ -146,11 +143,17 @@
 
 	.stats {
 		grid-template-columns: repeat(3, minmax(0, 1fr));
+		column-gap: var(--space-3);
 	}
 
 	.filterGroups {
 		grid-template-columns: auto minmax(0, 1fr);
 		align-items: start;
 		column-gap: var(--space-4);
+	}
+
+	.stat + .stat {
+		padding-left: var(--space-2);
+		border-left: 1px solid var(--color-library-rule);
 	}
 }

--- a/src/lib/organisms/library_experience/LibraryExperience.module.css
+++ b/src/lib/organisms/library_experience/LibraryExperience.module.css
@@ -36,6 +36,7 @@
 
 .intro,
 .filtersCopy p,
+.collectionHeader p,
 .empty p {
 	margin: 0;
 	font-size: var(--font-size-body-lg);
@@ -70,6 +71,19 @@
 	font-weight: var(--font-weight-medium);
 }
 
+.filterGroups,
+.filterGroup {
+	display: grid;
+	gap: var(--space-2);
+}
+
+.filterLabel {
+	margin: 0;
+	font-size: 0.9rem;
+	font-weight: var(--font-weight-semibold);
+	color: var(--color-library-card-meta);
+}
+
 .filterList {
 	display: flex;
 	flex-wrap: wrap;
@@ -101,9 +115,18 @@
 	color: var(--color-library-filter-text-active);
 }
 
-.shelves {
+.collection {
 	display: grid;
-	gap: var(--space-4);
+	gap: var(--space-3);
+}
+
+.collectionHeader {
+	display: grid;
+	gap: var(--space-1);
+}
+
+.collectionHeader h2 {
+	margin: 0;
 }
 
 .empty {
@@ -123,5 +146,11 @@
 
 	.stats {
 		grid-template-columns: repeat(3, minmax(0, 1fr));
+	}
+
+	.filterGroups {
+		grid-template-columns: auto minmax(0, 1fr);
+		align-items: start;
+		column-gap: var(--space-4);
 	}
 }

--- a/src/lib/organisms/library_experience/LibraryExperience.module.css
+++ b/src/lib/organisms/library_experience/LibraryExperience.module.css
@@ -1,0 +1,127 @@
+.libraryPage {
+	padding-block: var(--space-5) var(--space-7);
+}
+
+.layout {
+	display: grid;
+	gap: var(--space-4);
+}
+
+.hero,
+.filters,
+.empty {
+	display: grid;
+	gap: var(--space-3);
+	padding: var(--space-4);
+	border: 1px solid var(--color-library-hero-border);
+	border-radius: 1.5rem;
+	background: var(--color-library-hero-surface);
+	box-shadow: var(--elevation-library-panel);
+}
+
+.heroCopy,
+.filtersCopy {
+	display: grid;
+	gap: var(--space-2);
+}
+
+.eyebrow {
+	margin: 0;
+	font-size: 0.85rem;
+	font-weight: var(--font-weight-semibold);
+	letter-spacing: 0.12em;
+	text-transform: uppercase;
+	color: var(--color-library-chip-text);
+}
+
+.intro,
+.filtersCopy p,
+.empty p {
+	margin: 0;
+	font-size: var(--font-size-body-lg);
+	line-height: var(--line-height-body);
+	color: var(--color-library-panel-muted);
+}
+
+.stats {
+	display: grid;
+	grid-template-columns: repeat(1, minmax(0, 1fr));
+	gap: var(--space-2);
+}
+
+.stat {
+	display: grid;
+	gap: 0.35rem;
+	padding: var(--space-3);
+	border: 1px solid var(--color-library-stat-border);
+	border-radius: 1rem;
+	background: var(--color-library-stat-surface);
+}
+
+.statValue {
+	font-family: var(--font-heading);
+	font-size: clamp(2rem, 5vw, 3rem);
+	line-height: 1;
+	color: var(--color-text-primary);
+}
+
+.statLabel {
+	color: var(--color-library-card-meta);
+	font-weight: var(--font-weight-medium);
+}
+
+.filterList {
+	display: flex;
+	flex-wrap: wrap;
+	gap: var(--space-1);
+}
+
+.filter {
+	padding: 0.75rem 1rem;
+	border: 1px solid var(--color-library-filter-border);
+	border-radius: 999px;
+	background: var(--color-library-filter-surface);
+	color: var(--color-text-primary);
+	font: inherit;
+	cursor: pointer;
+}
+
+.filter:hover {
+	background: var(--color-library-filter-surface-hover);
+}
+
+.filter:focus-visible {
+	outline: 3px solid var(--color-focus-ring);
+	outline-offset: 3px;
+}
+
+.filterActive {
+	border-color: var(--color-library-filter-border-active);
+	background: var(--color-library-filter-surface-active);
+	color: var(--color-library-filter-text-active);
+}
+
+.shelves {
+	display: grid;
+	gap: var(--space-4);
+}
+
+.empty {
+	background: var(--color-library-empty-surface);
+	border-color: var(--color-library-empty-border);
+}
+
+.empty h2 {
+	margin: 0;
+}
+
+@media (min-width: 48rem) {
+	.hero {
+		grid-template-columns: minmax(0, 1.35fr) minmax(18rem, 0.85fr);
+		align-items: stretch;
+	}
+
+	.stats {
+		grid-template-columns: repeat(3, minmax(0, 1fr));
+	}
+}

--- a/src/lib/organisms/library_experience/LibraryExperience.module.css
+++ b/src/lib/organisms/library_experience/LibraryExperience.module.css
@@ -1,17 +1,17 @@
 .libraryPage {
-	padding-block: var(--space-5) var(--space-7);
+	padding-block: var(--space-4) var(--space-7);
 }
 
 .layout {
 	display: grid;
-	gap: var(--space-5);
+	gap: var(--space-4);
 }
 
 .hero,
 .filters,
 .empty {
 	display: grid;
-	gap: var(--space-3);
+	gap: var(--space-2);
 	padding-block: 0;
 }
 
@@ -19,6 +19,7 @@
 .filtersCopy {
 	display: grid;
 	gap: var(--space-2);
+	max-inline-size: 42rem;
 }
 
 .eyebrow {
@@ -41,21 +42,22 @@
 }
 
 .stats {
-	display: grid;
-	grid-template-columns: repeat(1, minmax(0, 1fr));
-	gap: var(--space-3);
+	display: flex;
+	flex-wrap: wrap;
+	gap: var(--space-2) var(--space-3);
+	align-items: baseline;
+	padding-top: var(--space-1);
 }
 
 .stat {
-	display: grid;
-	gap: 0.2rem;
-	padding-top: var(--space-2);
-	border-top: 1px solid var(--color-library-rule);
+	display: inline-flex;
+	align-items: baseline;
+	gap: 0.5rem;
 }
 
 .statValue {
 	font-family: var(--font-heading);
-	font-size: clamp(2rem, 5vw, 3rem);
+	font-size: clamp(1.5rem, 3vw, 2.25rem);
 	line-height: 1;
 	color: var(--color-text-primary);
 }
@@ -63,12 +65,17 @@
 .statLabel {
 	color: var(--color-library-card-meta);
 	font-weight: var(--font-weight-medium);
+	font-size: 0.95rem;
 }
 
 .filterGroups,
 .filterGroup {
 	display: grid;
 	gap: var(--space-2);
+}
+
+.filterGroups {
+	padding-top: var(--space-1);
 }
 
 .filterLabel {
@@ -112,14 +119,12 @@
 
 .collection {
 	display: grid;
-	gap: var(--space-3);
+	gap: var(--space-2);
 }
 
 .collectionHeader {
 	display: grid;
 	gap: var(--space-1);
-	padding-bottom: var(--space-2);
-	border-bottom: 1px solid var(--color-library-rule);
 }
 
 .collectionHeader h2 {
@@ -138,22 +143,19 @@
 @media (min-width: 48rem) {
 	.hero {
 		grid-template-columns: minmax(0, 1.35fr) minmax(18rem, 0.85fr);
-		align-items: stretch;
+		align-items: end;
+		column-gap: var(--space-4);
 	}
 
 	.stats {
-		grid-template-columns: repeat(3, minmax(0, 1fr));
-		column-gap: var(--space-3);
+		justify-content: flex-start;
+		align-content: end;
+		row-gap: var(--space-1);
 	}
 
 	.filterGroups {
 		grid-template-columns: auto minmax(0, 1fr);
 		align-items: start;
 		column-gap: var(--space-4);
-	}
-
-	.stat + .stat {
-		padding-left: var(--space-2);
-		border-left: 1px solid var(--color-library-rule);
 	}
 }

--- a/src/lib/organisms/library_experience/LibraryExperience.module.css
+++ b/src/lib/organisms/library_experience/LibraryExperience.module.css
@@ -1,5 +1,6 @@
 .libraryPage {
 	padding-block: var(--space-4) var(--space-7);
+	background: var(--color-white);
 }
 
 .layout {

--- a/src/lib/organisms/library_experience/LibraryExperience.stories.svelte
+++ b/src/lib/organisms/library_experience/LibraryExperience.stories.svelte
@@ -13,7 +13,7 @@
 			docs: {
 				description: {
 					component:
-						'Curated Library landing experience with bookshelf styling, topic filters, and split shelves for books and articles. Use when you need a destination page that feels editorial instead of archive-like.'
+						'Curated Library landing experience with one mixed reading grid, topic and type filters, and lightweight card chrome for books and articles. Use when you need a destination page that feels editorial instead of archive-like.'
 				}
 			}
 		}

--- a/src/lib/organisms/library_experience/LibraryExperience.stories.svelte
+++ b/src/lib/organisms/library_experience/LibraryExperience.stories.svelte
@@ -1,0 +1,28 @@
+<script context="module" lang="ts">
+	import { defineMeta } from '@storybook/addon-svelte-csf';
+	import LibraryExperience from './LibraryExperience.svelte';
+	import { getLibraryPageData } from '$lib/services/library/library';
+
+	const baseArgs = getLibraryPageData();
+
+	const { Story } = defineMeta({
+		title: 'Design System/Organisms/LibraryExperience',
+		component: LibraryExperience,
+		args: baseArgs,
+		parameters: {
+			docs: {
+				description: {
+					component:
+						'Curated Library landing experience with bookshelf styling, topic filters, and split shelves for books and articles. Use when you need a destination page that feels editorial instead of archive-like.'
+				}
+			}
+		}
+	});
+</script>
+
+<Story name="Default" args={baseArgs} />
+<Story
+	name="Mobile viewport"
+	args={baseArgs}
+	parameters={{ viewport: { defaultViewport: 'mobile1' } }}
+/>

--- a/src/lib/organisms/library_experience/LibraryExperience.svelte
+++ b/src/lib/organisms/library_experience/LibraryExperience.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import Container from '$lib/atoms/container/Container.svelte';
 	import LibraryShelf from '$lib/organisms/library_shelf/LibraryShelf.svelte';
-	import type { LibraryEntry } from '$lib/services/library/library';
+	import type { LibraryEntry, LibraryEntryType } from '$lib/services/library/library';
 	import styles from './LibraryExperience.module.css';
 
 	interface Props {
@@ -15,18 +15,63 @@
 
 	let { entries, topics, counts }: Props = $props();
 	let activeTopic = $state('all');
+	let activeTypes = $state<LibraryEntryType[]>(['book', 'article']);
 
 	function formatTopic(topic: string) {
 		return topic.replace(/\b\w/g, (character) => character.toUpperCase());
 	}
 
+	function isTypeActive(type: LibraryEntryType) {
+		return activeTypes.includes(type);
+	}
+
+	function toggleType(type: LibraryEntryType) {
+		if (activeTypes.includes(type)) {
+			if (activeTypes.length === 1) {
+				return;
+			}
+
+			activeTypes = activeTypes.filter((value) => value !== type);
+			return;
+		}
+
+		activeTypes = [...activeTypes, type];
+	}
+
+	function interleaveEntries(books: LibraryEntry[], articles: LibraryEntry[]) {
+		const mixed: LibraryEntry[] = [];
+		const maxLength = Math.max(books.length, articles.length);
+
+		for (let index = 0; index < maxLength; index += 1) {
+			const book = books[index];
+			const article = articles[index];
+
+			if (book) {
+				mixed.push(book);
+			}
+
+			if (article) {
+				mixed.push(article);
+			}
+		}
+
+		return mixed;
+	}
+
 	const filteredEntries = $derived(
-		activeTopic === 'all' ? entries : entries.filter((entry) => entry.topics.includes(activeTopic))
+		entries.filter((entry) => {
+			const matchesTopic = activeTopic === 'all' || entry.topics.includes(activeTopic);
+			const matchesType = activeTypes.includes(entry.type);
+			return matchesTopic && matchesType;
+		})
 	);
 	const filteredBooks = $derived(filteredEntries.filter((entry) => entry.type === 'book'));
 	const filteredArticles = $derived(filteredEntries.filter((entry) => entry.type === 'article'));
+	const mixedEntries = $derived(
+		activeTypes.length === 2 ? interleaveEntries(filteredBooks, filteredArticles) : filteredEntries
+	);
 	const resultSummary = $derived(
-		`${filteredBooks.length} book${filteredBooks.length === 1 ? '' : 's'} and ${filteredArticles.length} article${filteredArticles.length === 1 ? '' : 's'}`
+		`${filteredEntries.length} pick${filteredEntries.length === 1 ? '' : 's'} showing ${filteredBooks.length} book${filteredBooks.length === 1 ? '' : 's'} and ${filteredArticles.length} article${filteredArticles.length === 1 ? '' : 's'}`
 	);
 </script>
 
@@ -48,9 +93,9 @@
 						A curated shelf of books and articles that keep the work honest.
 					</h1>
 					<p class={styles.intro}>
-						A working collection for leadership, delivery, design systems, and strategy. Use topic
-						filters to move across the full mix without losing the split between longer books and
-						shorter field notes.
+						A working collection for leadership, delivery, design systems, and strategy. Books and
+						articles sit together in one reading grid, with filters to narrow by topic or content
+						type when you need a sharper view.
 					</p>
 				</div>
 
@@ -72,64 +117,86 @@
 
 			<section class={styles.filters} aria-labelledby="library-filter-heading">
 				<div class={styles.filtersCopy}>
-					<h2 id="library-filter-heading">Browse by topic</h2>
-					<p>
-						Filter once and the whole library rebalances itself. The current selection shows
-						{resultSummary}.
-					</p>
+					<h2 id="library-filter-heading">Browse the collection</h2>
+					<p>Filter by topic or content type. The current selection shows {resultSummary}.</p>
 				</div>
 
-				<div class={styles.filterList} role="toolbar" aria-label="Library topic filters">
-					<button
-						type="button"
-						class={`${styles.filter}${activeTopic === 'all' ? ` ${styles.filterActive}` : ''}`}
-						aria-pressed={activeTopic === 'all'}
-						onclick={() => {
-							activeTopic = 'all';
-						}}
-					>
-						All topics
-					</button>
+				<div class={styles.filterGroups}>
+					<div class={styles.filterGroup}>
+						<p class={styles.filterLabel}>Type</p>
+						<div class={styles.filterList} role="toolbar" aria-label="Library type filters">
+							<button
+								type="button"
+								class={`${styles.filter}${isTypeActive('book') ? ` ${styles.filterActive}` : ''}`}
+								aria-pressed={isTypeActive('book')}
+								onclick={() => {
+									toggleType('book');
+								}}
+							>
+								Books
+							</button>
+							<button
+								type="button"
+								class={`${styles.filter}${isTypeActive('article') ? ` ${styles.filterActive}` : ''}`}
+								aria-pressed={isTypeActive('article')}
+								onclick={() => {
+									toggleType('article');
+								}}
+							>
+								Articles
+							</button>
+						</div>
+					</div>
 
-					{#each topics as topic (topic)}
-						<button
-							type="button"
-							class={`${styles.filter}${activeTopic === topic ? ` ${styles.filterActive}` : ''}`}
-							aria-pressed={activeTopic === topic}
-							onclick={() => {
-								activeTopic = topic;
-							}}
-						>
-							{formatTopic(topic)}
-						</button>
-					{/each}
+					<div class={styles.filterGroup}>
+						<p class={styles.filterLabel}>Topic</p>
+						<div class={styles.filterList} role="toolbar" aria-label="Library topic filters">
+							<button
+								type="button"
+								class={`${styles.filter}${activeTopic === 'all' ? ` ${styles.filterActive}` : ''}`}
+								aria-pressed={activeTopic === 'all'}
+								onclick={() => {
+									activeTopic = 'all';
+								}}
+							>
+								All topics
+							</button>
+
+							{#each topics as topic (topic)}
+								<button
+									type="button"
+									class={`${styles.filter}${activeTopic === topic ? ` ${styles.filterActive}` : ''}`}
+									aria-pressed={activeTopic === topic}
+									onclick={() => {
+										activeTopic = topic;
+									}}
+								>
+									{formatTopic(topic)}
+								</button>
+							{/each}
+						</div>
+					</div>
 				</div>
 			</section>
 
 			{#if filteredEntries.length}
-				<div class={styles.shelves}>
-					{#if filteredBooks.length}
-						<LibraryShelf
-							title="Books"
-							description="Longer-form thinking worth revisiting when systems, teams, or roadmaps need steadier foundations."
-							items={filteredBooks}
-						/>
-					{/if}
+				<section class={styles.collection} aria-labelledby="library-collection-heading">
+					<div class={styles.collectionHeader}>
+						<h2 id="library-collection-heading">Reading now</h2>
+						<p>
+							Every card shares the same grid, so books and articles can sit together when both are
+							active.
+						</p>
+					</div>
 
-					{#if filteredArticles.length}
-						<LibraryShelf
-							title="Articles"
-							description="Shorter field notes and essays for the moves that matter between planning, facilitation, and execution."
-							items={filteredArticles}
-						/>
-					{/if}
-				</div>
+					<LibraryShelf items={mixedEntries} />
+				</section>
 			{:else}
 				<section class={styles.empty}>
 					<h2>No matches yet</h2>
 					<p>
-						Try another topic to reopen the shelf. This view keeps the filter set narrow on purpose
-						so the collection still feels curated instead of exhaustive.
+						Try another topic or turn a content type back on to reopen the collection. At least one
+						type filter always stays active so the view never collapses by accident.
 					</p>
 				</section>
 			{/if}

--- a/src/lib/organisms/library_experience/LibraryExperience.svelte
+++ b/src/lib/organisms/library_experience/LibraryExperience.svelte
@@ -1,0 +1,269 @@
+<script lang="ts">
+	import Container from '$lib/atoms/container/Container.svelte';
+	import LibraryShelf from '$lib/organisms/library_shelf/LibraryShelf.svelte';
+	import type { LibraryEntry } from '$lib/services/library/library';
+
+	interface Props {
+		entries: LibraryEntry[];
+		topics: string[];
+		counts: {
+			books: number;
+			articles: number;
+		};
+	}
+
+	let { entries, topics, counts }: Props = $props();
+	let activeTopic = $state('all');
+
+	function formatTopic(topic: string) {
+		return topic.replace(/\b\w/g, (character) => character.toUpperCase());
+	}
+
+	const filteredEntries = $derived(
+		activeTopic === 'all' ? entries : entries.filter((entry) => entry.topics.includes(activeTopic))
+	);
+	const filteredBooks = $derived(filteredEntries.filter((entry) => entry.type === 'book'));
+	const filteredArticles = $derived(filteredEntries.filter((entry) => entry.type === 'article'));
+	const resultSummary = $derived(
+		`${filteredBooks.length} book${filteredBooks.length === 1 ? '' : 's'} and ${filteredArticles.length} article${filteredArticles.length === 1 ? '' : 's'}`
+	);
+</script>
+
+<svelte:head>
+	<title>Chris I Powell - Library</title>
+	<meta
+		name="description"
+		content="A curated shelf of books and articles shaping how Chris I Powell leads teams, designs systems, and ships meaningful work."
+	/>
+</svelte:head>
+
+<main class="library-page">
+	<Container>
+		<div class="library-page__layout">
+			<section class="library-page__hero" aria-labelledby="library-heading">
+				<div class="library-page__hero-copy">
+					<p class="library-page__eyebrow">Library</p>
+					<h1 id="library-heading">
+						A curated shelf of books and articles that keep the work honest.
+					</h1>
+					<p class="library-page__intro">
+						A working collection for leadership, delivery, design systems, and strategy. Use topic
+						filters to move across the full mix without losing the split between longer books and
+						shorter field notes.
+					</p>
+				</div>
+
+				<div class="library-page__stats" role="list" aria-label="Library totals">
+					<div class="library-page__stat" role="listitem">
+						<span class="library-page__stat-value">{counts.books}</span>
+						<span class="library-page__stat-label">Books</span>
+					</div>
+					<div class="library-page__stat" role="listitem">
+						<span class="library-page__stat-value">{counts.articles}</span>
+						<span class="library-page__stat-label">Articles</span>
+					</div>
+					<div class="library-page__stat" role="listitem">
+						<span class="library-page__stat-value">{topics.length}</span>
+						<span class="library-page__stat-label">Topics</span>
+					</div>
+				</div>
+			</section>
+
+			<section class="library-page__filters" aria-labelledby="library-filter-heading">
+				<div class="library-page__filters-copy">
+					<h2 id="library-filter-heading">Browse by topic</h2>
+					<p>
+						Filter once and the whole library rebalances itself. The current selection shows
+						{resultSummary}.
+					</p>
+				</div>
+
+				<div class="library-page__filter-list" role="toolbar" aria-label="Library topic filters">
+					<button
+						type="button"
+						class:library-page__filter-active={activeTopic === 'all'}
+						class="library-page__filter"
+						aria-pressed={activeTopic === 'all'}
+						onclick={() => {
+							activeTopic = 'all';
+						}}
+					>
+						All topics
+					</button>
+
+					{#each topics as topic (topic)}
+						<button
+							type="button"
+							class:library-page__filter-active={activeTopic === topic}
+							class="library-page__filter"
+							aria-pressed={activeTopic === topic}
+							onclick={() => {
+								activeTopic = topic;
+							}}
+						>
+							{formatTopic(topic)}
+						</button>
+					{/each}
+				</div>
+			</section>
+
+			{#if filteredEntries.length}
+				<div class="library-page__shelves">
+					{#if filteredBooks.length}
+						<LibraryShelf
+							title="Books"
+							description="Longer-form thinking worth revisiting when systems, teams, or roadmaps need steadier foundations."
+							items={filteredBooks}
+						/>
+					{/if}
+
+					{#if filteredArticles.length}
+						<LibraryShelf
+							title="Articles"
+							description="Shorter field notes and essays for the moves that matter between planning, facilitation, and execution."
+							items={filteredArticles}
+						/>
+					{/if}
+				</div>
+			{:else}
+				<section class="library-page__empty">
+					<h2>No matches yet</h2>
+					<p>
+						Try another topic to reopen the shelf. This view keeps the filter set narrow on purpose
+						so the collection still feels curated instead of exhaustive.
+					</p>
+				</section>
+			{/if}
+		</div>
+	</Container>
+</main>
+
+<style>
+	.library-page {
+		padding-block: var(--space-5) var(--space-7);
+	}
+
+	.library-page__layout {
+		display: grid;
+		gap: var(--space-4);
+	}
+
+	.library-page__hero,
+	.library-page__filters,
+	.library-page__empty {
+		display: grid;
+		gap: var(--space-3);
+		padding: var(--space-4);
+		border: 1px solid var(--color-library-hero-border);
+		border-radius: 1.5rem;
+		background: var(--color-library-hero-surface);
+		box-shadow: var(--elevation-library-panel);
+	}
+
+	.library-page__hero-copy,
+	.library-page__filters-copy {
+		display: grid;
+		gap: var(--space-2);
+	}
+
+	.library-page__eyebrow {
+		margin: 0;
+		font-size: 0.85rem;
+		font-weight: var(--font-weight-semibold);
+		letter-spacing: 0.12em;
+		text-transform: uppercase;
+		color: var(--color-library-chip-text);
+	}
+
+	.library-page__intro,
+	.library-page__filters-copy p,
+	.library-page__empty p {
+		margin: 0;
+		font-size: var(--font-size-body-lg);
+		line-height: var(--line-height-body);
+		color: var(--color-library-panel-muted);
+	}
+
+	.library-page__stats {
+		display: grid;
+		grid-template-columns: repeat(1, minmax(0, 1fr));
+		gap: var(--space-2);
+	}
+
+	.library-page__stat {
+		display: grid;
+		gap: 0.35rem;
+		padding: var(--space-3);
+		border: 1px solid var(--color-library-stat-border);
+		border-radius: 1rem;
+		background: var(--color-library-stat-surface);
+	}
+
+	.library-page__stat-value {
+		font-family: var(--font-heading);
+		font-size: clamp(2rem, 5vw, 3rem);
+		line-height: 1;
+		color: var(--color-text-primary);
+	}
+
+	.library-page__stat-label {
+		color: var(--color-library-card-meta);
+		font-weight: var(--font-weight-medium);
+	}
+
+	.library-page__filter-list {
+		display: flex;
+		flex-wrap: wrap;
+		gap: var(--space-1);
+	}
+
+	.library-page__filter {
+		padding: 0.75rem 1rem;
+		border: 1px solid var(--color-library-filter-border);
+		border-radius: 999px;
+		background: var(--color-library-filter-surface);
+		color: var(--color-text-primary);
+		font: inherit;
+		cursor: pointer;
+	}
+
+	.library-page__filter:hover {
+		background: var(--color-library-filter-surface-hover);
+	}
+
+	.library-page__filter:focus-visible {
+		outline: 3px solid var(--color-focus-ring);
+		outline-offset: 3px;
+	}
+
+	.library-page__filter-active {
+		border-color: var(--color-library-filter-border-active);
+		background: var(--color-library-filter-surface-active);
+		color: var(--color-library-filter-text-active);
+	}
+
+	.library-page__shelves {
+		display: grid;
+		gap: var(--space-4);
+	}
+
+	.library-page__empty {
+		background: var(--color-library-empty-surface);
+		border-color: var(--color-library-empty-border);
+	}
+
+	.library-page__empty h2 {
+		margin: 0;
+	}
+
+	@media (min-width: 48rem) {
+		.library-page__hero {
+			grid-template-columns: minmax(0, 1.35fr) minmax(18rem, 0.85fr);
+			align-items: stretch;
+		}
+
+		.library-page__stats {
+			grid-template-columns: repeat(3, minmax(0, 1fr));
+		}
+	}
+</style>

--- a/src/lib/organisms/library_experience/LibraryExperience.svelte
+++ b/src/lib/organisms/library_experience/LibraryExperience.svelte
@@ -2,6 +2,7 @@
 	import Container from '$lib/atoms/container/Container.svelte';
 	import LibraryShelf from '$lib/organisms/library_shelf/LibraryShelf.svelte';
 	import type { LibraryEntry } from '$lib/services/library/library';
+	import styles from './LibraryExperience.module.css';
 
 	interface Props {
 		entries: LibraryEntry[];
@@ -37,40 +38,40 @@
 	/>
 </svelte:head>
 
-<main class="library-page">
+<main class={styles.libraryPage}>
 	<Container>
-		<div class="library-page__layout">
-			<section class="library-page__hero" aria-labelledby="library-heading">
-				<div class="library-page__hero-copy">
-					<p class="library-page__eyebrow">Library</p>
+		<div class={styles.layout}>
+			<section class={styles.hero} aria-labelledby="library-heading">
+				<div class={styles.heroCopy}>
+					<p class={styles.eyebrow}>Library</p>
 					<h1 id="library-heading">
 						A curated shelf of books and articles that keep the work honest.
 					</h1>
-					<p class="library-page__intro">
+					<p class={styles.intro}>
 						A working collection for leadership, delivery, design systems, and strategy. Use topic
 						filters to move across the full mix without losing the split between longer books and
 						shorter field notes.
 					</p>
 				</div>
 
-				<div class="library-page__stats" role="list" aria-label="Library totals">
-					<div class="library-page__stat" role="listitem">
-						<span class="library-page__stat-value">{counts.books}</span>
-						<span class="library-page__stat-label">Books</span>
+				<div class={styles.stats} role="list" aria-label="Library totals">
+					<div class={styles.stat} role="listitem">
+						<span class={styles.statValue}>{counts.books}</span>
+						<span class={styles.statLabel}>Books</span>
 					</div>
-					<div class="library-page__stat" role="listitem">
-						<span class="library-page__stat-value">{counts.articles}</span>
-						<span class="library-page__stat-label">Articles</span>
+					<div class={styles.stat} role="listitem">
+						<span class={styles.statValue}>{counts.articles}</span>
+						<span class={styles.statLabel}>Articles</span>
 					</div>
-					<div class="library-page__stat" role="listitem">
-						<span class="library-page__stat-value">{topics.length}</span>
-						<span class="library-page__stat-label">Topics</span>
+					<div class={styles.stat} role="listitem">
+						<span class={styles.statValue}>{topics.length}</span>
+						<span class={styles.statLabel}>Topics</span>
 					</div>
 				</div>
 			</section>
 
-			<section class="library-page__filters" aria-labelledby="library-filter-heading">
-				<div class="library-page__filters-copy">
+			<section class={styles.filters} aria-labelledby="library-filter-heading">
+				<div class={styles.filtersCopy}>
 					<h2 id="library-filter-heading">Browse by topic</h2>
 					<p>
 						Filter once and the whole library rebalances itself. The current selection shows
@@ -78,11 +79,10 @@
 					</p>
 				</div>
 
-				<div class="library-page__filter-list" role="toolbar" aria-label="Library topic filters">
+				<div class={styles.filterList} role="toolbar" aria-label="Library topic filters">
 					<button
 						type="button"
-						class:library-page__filter-active={activeTopic === 'all'}
-						class="library-page__filter"
+						class={`${styles.filter}${activeTopic === 'all' ? ` ${styles.filterActive}` : ''}`}
 						aria-pressed={activeTopic === 'all'}
 						onclick={() => {
 							activeTopic = 'all';
@@ -94,8 +94,7 @@
 					{#each topics as topic (topic)}
 						<button
 							type="button"
-							class:library-page__filter-active={activeTopic === topic}
-							class="library-page__filter"
+							class={`${styles.filter}${activeTopic === topic ? ` ${styles.filterActive}` : ''}`}
 							aria-pressed={activeTopic === topic}
 							onclick={() => {
 								activeTopic = topic;
@@ -108,7 +107,7 @@
 			</section>
 
 			{#if filteredEntries.length}
-				<div class="library-page__shelves">
+				<div class={styles.shelves}>
 					{#if filteredBooks.length}
 						<LibraryShelf
 							title="Books"
@@ -126,7 +125,7 @@
 					{/if}
 				</div>
 			{:else}
-				<section class="library-page__empty">
+				<section class={styles.empty}>
 					<h2>No matches yet</h2>
 					<p>
 						Try another topic to reopen the shelf. This view keeps the filter set narrow on purpose
@@ -137,133 +136,3 @@
 		</div>
 	</Container>
 </main>
-
-<style>
-	.library-page {
-		padding-block: var(--space-5) var(--space-7);
-	}
-
-	.library-page__layout {
-		display: grid;
-		gap: var(--space-4);
-	}
-
-	.library-page__hero,
-	.library-page__filters,
-	.library-page__empty {
-		display: grid;
-		gap: var(--space-3);
-		padding: var(--space-4);
-		border: 1px solid var(--color-library-hero-border);
-		border-radius: 1.5rem;
-		background: var(--color-library-hero-surface);
-		box-shadow: var(--elevation-library-panel);
-	}
-
-	.library-page__hero-copy,
-	.library-page__filters-copy {
-		display: grid;
-		gap: var(--space-2);
-	}
-
-	.library-page__eyebrow {
-		margin: 0;
-		font-size: 0.85rem;
-		font-weight: var(--font-weight-semibold);
-		letter-spacing: 0.12em;
-		text-transform: uppercase;
-		color: var(--color-library-chip-text);
-	}
-
-	.library-page__intro,
-	.library-page__filters-copy p,
-	.library-page__empty p {
-		margin: 0;
-		font-size: var(--font-size-body-lg);
-		line-height: var(--line-height-body);
-		color: var(--color-library-panel-muted);
-	}
-
-	.library-page__stats {
-		display: grid;
-		grid-template-columns: repeat(1, minmax(0, 1fr));
-		gap: var(--space-2);
-	}
-
-	.library-page__stat {
-		display: grid;
-		gap: 0.35rem;
-		padding: var(--space-3);
-		border: 1px solid var(--color-library-stat-border);
-		border-radius: 1rem;
-		background: var(--color-library-stat-surface);
-	}
-
-	.library-page__stat-value {
-		font-family: var(--font-heading);
-		font-size: clamp(2rem, 5vw, 3rem);
-		line-height: 1;
-		color: var(--color-text-primary);
-	}
-
-	.library-page__stat-label {
-		color: var(--color-library-card-meta);
-		font-weight: var(--font-weight-medium);
-	}
-
-	.library-page__filter-list {
-		display: flex;
-		flex-wrap: wrap;
-		gap: var(--space-1);
-	}
-
-	.library-page__filter {
-		padding: 0.75rem 1rem;
-		border: 1px solid var(--color-library-filter-border);
-		border-radius: 999px;
-		background: var(--color-library-filter-surface);
-		color: var(--color-text-primary);
-		font: inherit;
-		cursor: pointer;
-	}
-
-	.library-page__filter:hover {
-		background: var(--color-library-filter-surface-hover);
-	}
-
-	.library-page__filter:focus-visible {
-		outline: 3px solid var(--color-focus-ring);
-		outline-offset: 3px;
-	}
-
-	.library-page__filter-active {
-		border-color: var(--color-library-filter-border-active);
-		background: var(--color-library-filter-surface-active);
-		color: var(--color-library-filter-text-active);
-	}
-
-	.library-page__shelves {
-		display: grid;
-		gap: var(--space-4);
-	}
-
-	.library-page__empty {
-		background: var(--color-library-empty-surface);
-		border-color: var(--color-library-empty-border);
-	}
-
-	.library-page__empty h2 {
-		margin: 0;
-	}
-
-	@media (min-width: 48rem) {
-		.library-page__hero {
-			grid-template-columns: minmax(0, 1.35fr) minmax(18rem, 0.85fr);
-			align-items: stretch;
-		}
-
-		.library-page__stats {
-			grid-template-columns: repeat(3, minmax(0, 1fr));
-		}
-	}
-</style>

--- a/src/lib/organisms/library_experience/LibraryExperience.test.ts
+++ b/src/lib/organisms/library_experience/LibraryExperience.test.ts
@@ -3,7 +3,7 @@ import { expect, test } from 'vitest';
 import LibraryExperience from './LibraryExperience.svelte';
 import { getLibraryPageData } from '$lib/services/library/library';
 
-test('renders bookshelf sections for books and articles', () => {
+test('renders one mixed collection with both books and articles visible by default', () => {
 	render(LibraryExperience, getLibraryPageData());
 
 	expect(
@@ -11,23 +11,38 @@ test('renders bookshelf sections for books and articles', () => {
 			name: 'A curated shelf of books and articles that keep the work honest.'
 		})
 	).toBeTruthy();
-	expect(screen.getByRole('heading', { name: 'Books' })).toBeTruthy();
-	expect(screen.getByRole('heading', { name: 'Articles' })).toBeTruthy();
+	expect(screen.getByRole('heading', { name: 'Reading now' })).toBeTruthy();
+	expect(screen.getByText('The Art of Gathering')).toBeTruthy();
+	expect(screen.getByText('Roadmaps, bets, and the cost of false certainty')).toBeTruthy();
+	expect(screen.getAllByLabelText('book recommendation').length).toBeGreaterThan(0);
+	expect(screen.getAllByLabelText('article recommendation').length).toBeGreaterThan(0);
 	expect(screen.getByRole('button', { name: 'All topics' }).getAttribute('aria-pressed')).toBe(
 		'true'
 	);
-	expect(screen.getByText(/The current selection shows\s+4 books and 4 articles\./)).toBeTruthy();
+	expect(screen.getByText(/8 picks showing 4 books and 4 articles\./)).toBeTruthy();
 });
 
-test('filters both shelves from a single topic selection', async () => {
+test('type filters can narrow the mixed collection to books only', async () => {
+	render(LibraryExperience, getLibraryPageData());
+
+	const articleButton = screen.getByRole('button', { name: 'Articles' });
+	await fireEvent.click(articleButton);
+
+	expect(articleButton.getAttribute('aria-pressed')).toBe('false');
+	expect(screen.getByText('The Art of Gathering')).toBeTruthy();
+	expect(screen.queryByText('Roadmaps, bets, and the cost of false certainty')).toBeNull();
+	expect(screen.getByText(/4 picks showing 4 books and 0 articles/)).toBeTruthy();
+});
+
+test('topic filters still narrow the mixed collection across both types', async () => {
 	render(LibraryExperience, getLibraryPageData());
 
 	const leadershipButton = screen.getByRole('button', { name: 'Leadership' });
 	await fireEvent.click(leadershipButton);
 
 	expect(leadershipButton.getAttribute('aria-pressed')).toBe('true');
-	expect(screen.getAllByText('2 on this shelf')).toHaveLength(2);
-	expect(screen.getByText('Roadmaps, bets, and the cost of false certainty')).toBeTruthy();
+	expect(screen.getByText('The Art of Gathering')).toBeTruthy();
+	expect(screen.getByText('What staff-plus leadership looks like at a humane pace')).toBeTruthy();
 	expect(screen.queryByText('Designing Data-Intensive Applications')).toBeNull();
-	expect(screen.getByText(/2 books and 2 articles/)).toBeTruthy();
+	expect(screen.getByText(/4 picks showing 2 books and 2 articles/)).toBeTruthy();
 });

--- a/src/lib/organisms/library_experience/LibraryExperience.test.ts
+++ b/src/lib/organisms/library_experience/LibraryExperience.test.ts
@@ -1,0 +1,33 @@
+import { fireEvent, render, screen } from '@testing-library/svelte';
+import { expect, test } from 'vitest';
+import LibraryExperience from './LibraryExperience.svelte';
+import { getLibraryPageData } from '$lib/services/library/library';
+
+test('renders bookshelf sections for books and articles', () => {
+	render(LibraryExperience, getLibraryPageData());
+
+	expect(
+		screen.getByRole('heading', {
+			name: 'A curated shelf of books and articles that keep the work honest.'
+		})
+	).toBeTruthy();
+	expect(screen.getByRole('heading', { name: 'Books' })).toBeTruthy();
+	expect(screen.getByRole('heading', { name: 'Articles' })).toBeTruthy();
+	expect(screen.getByRole('button', { name: 'All topics' }).getAttribute('aria-pressed')).toBe(
+		'true'
+	);
+	expect(screen.getByText(/The current selection shows\s+4 books and 4 articles\./)).toBeTruthy();
+});
+
+test('filters both shelves from a single topic selection', async () => {
+	render(LibraryExperience, getLibraryPageData());
+
+	const leadershipButton = screen.getByRole('button', { name: 'Leadership' });
+	await fireEvent.click(leadershipButton);
+
+	expect(leadershipButton.getAttribute('aria-pressed')).toBe('true');
+	expect(screen.getAllByText('2 on this shelf')).toHaveLength(2);
+	expect(screen.getByText('Roadmaps, bets, and the cost of false certainty')).toBeTruthy();
+	expect(screen.queryByText('Designing Data-Intensive Applications')).toBeNull();
+	expect(screen.getByText(/2 books and 2 articles/)).toBeTruthy();
+});

--- a/src/lib/organisms/library_shelf/LibraryShelf.module.css
+++ b/src/lib/organisms/library_shelf/LibraryShelf.module.css
@@ -2,7 +2,8 @@
 	list-style: none;
 	display: grid;
 	grid-template-columns: repeat(1, minmax(0, 1fr));
-	gap: var(--space-3);
+	column-gap: var(--space-3);
+	row-gap: var(--space-4);
 	margin: 0;
 	padding: 0;
 }
@@ -15,11 +16,9 @@
 	display: grid;
 	gap: var(--space-2);
 	height: 100%;
-	padding: var(--space-3) var(--space-3) calc(var(--space-3) + 0.15rem);
-	border: 1px solid var(--color-library-card-border);
-	border-radius: 1.15rem;
-	background: var(--color-library-card-surface);
-	box-shadow: var(--elevation-library-card);
+	padding-block: var(--space-3);
+	border-top: 1px solid var(--color-library-card-border);
+	background: transparent;
 }
 
 .header {
@@ -41,37 +40,24 @@
 .typeLabel {
 	display: inline-flex;
 	align-items: center;
-	padding: 0.3rem 0.7rem;
-	border-radius: 999px;
-	background: var(--color-library-chip-surface);
-	color: var(--color-library-chip-text);
+	color: var(--color-library-type-label);
 	font-size: 0.8rem;
 	font-weight: var(--font-weight-semibold);
 	text-transform: uppercase;
 	letter-spacing: 0.08em;
 }
 
-.iconBadge {
+.iconMarker {
 	display: inline-flex;
 	align-items: center;
 	justify-content: center;
 	flex-shrink: 0;
-	inline-size: 2.25rem;
-	block-size: 2.25rem;
-	border: 1px solid var(--color-library-icon-border);
-	border-radius: 999px;
-	background: var(--color-library-icon-surface);
 	color: var(--color-library-icon);
 }
 
 .icon {
-	inline-size: 1.1rem;
-	block-size: 1.1rem;
-	fill: none;
-	stroke: currentColor;
-	stroke-linecap: round;
-	stroke-linejoin: round;
-	stroke-width: 1.8;
+	inline-size: 1.125rem;
+	block-size: 1.125rem;
 }
 
 .copy {
@@ -100,28 +86,41 @@
 	list-style: none;
 	display: flex;
 	flex-wrap: wrap;
-	gap: 0.75rem;
+	column-gap: 0.75rem;
+	row-gap: 0.25rem;
 	margin: 0;
 	padding: 0;
 }
 
 .topics li {
-	padding: 0.4rem 0.75rem;
-	border-radius: 999px;
-	background: var(--color-library-topic-surface);
 	color: var(--color-library-topic-text);
 	font-size: 0.85rem;
+	position: relative;
+	padding-left: 0.75rem;
+}
+
+.topics li::before {
+	content: '';
+	position: absolute;
+	left: 0;
+	top: 50%;
+	inline-size: 0.3rem;
+	block-size: 0.3rem;
+	border-radius: 999px;
+	background: var(--color-library-topic-marker);
+	transform: translateY(-50%);
 }
 
 @media (hover: hover) and (prefers-reduced-motion: no-preference) {
 	.card {
 		transition:
 			transform 180ms ease,
-			box-shadow 180ms ease;
+			border-color 180ms ease;
 	}
 
 	.card:hover {
-		transform: translateY(-0.2rem);
+		transform: translateY(-0.15rem);
+		border-color: var(--color-library-card-border-strong);
 	}
 }
 

--- a/src/lib/organisms/library_shelf/LibraryShelf.module.css
+++ b/src/lib/organisms/library_shelf/LibraryShelf.module.css
@@ -1,0 +1,171 @@
+.shelf {
+	display: grid;
+	gap: var(--space-3);
+	padding: var(--space-4);
+	border: 1px solid var(--color-library-panel-border);
+	border-radius: 1.5rem;
+	background: var(--color-library-panel-surface);
+	box-shadow: var(--elevation-library-panel);
+}
+
+.header {
+	display: grid;
+	gap: var(--space-2);
+	align-items: end;
+}
+
+.header h2,
+.copy h3,
+.count {
+	margin: 0;
+}
+
+.header p {
+	margin: 0;
+	color: var(--color-library-panel-muted);
+}
+
+.count {
+	font-size: 0.95rem;
+	font-weight: var(--font-weight-semibold);
+	color: var(--color-library-chip-text);
+}
+
+.grid {
+	list-style: none;
+	display: grid;
+	grid-template-columns: repeat(1, minmax(0, 1fr));
+	gap: var(--space-3);
+	margin: 0;
+	padding: 0 0 var(--space-3);
+	position: relative;
+}
+
+.grid::after {
+	content: '';
+	position: absolute;
+	inset: auto 0 0;
+	height: 0.95rem;
+	border-radius: 999px;
+	background: linear-gradient(
+		180deg,
+		var(--color-library-shelf-rail-top),
+		var(--color-library-shelf-rail-bottom)
+	);
+	box-shadow: var(--elevation-library-rail);
+}
+
+.item {
+	position: relative;
+	z-index: 1;
+}
+
+.card {
+	display: grid;
+	gap: var(--space-2);
+	height: 100%;
+	padding: var(--space-3);
+	border: 1px solid var(--color-library-card-border);
+	border-radius: 1.15rem;
+	background: var(--color-library-card-surface);
+	box-shadow: var(--elevation-library-card);
+	position: relative;
+	overflow: hidden;
+}
+
+.card::before {
+	content: '';
+	position: absolute;
+	inset: 0 auto 0 0;
+	width: 0.55rem;
+	background: var(--color-library-accent-amber);
+}
+
+.cardSage::before {
+	background: var(--color-library-accent-sage);
+}
+
+.cardInk::before {
+	background: var(--color-library-accent-ink);
+}
+
+.cardRose::before {
+	background: var(--color-library-accent-rose);
+}
+
+.meta {
+	display: flex;
+	flex-wrap: wrap;
+	gap: var(--space-1);
+	align-items: center;
+	font-size: 0.9rem;
+	color: var(--color-library-card-meta);
+}
+
+.chip {
+	display: inline-flex;
+	align-items: center;
+	padding: 0.3rem 0.7rem;
+	border-radius: 999px;
+	background: var(--color-library-chip-surface);
+	color: var(--color-library-chip-text);
+	font-size: 0.8rem;
+	font-weight: var(--font-weight-semibold);
+	text-transform: uppercase;
+	letter-spacing: 0.08em;
+}
+
+.copy {
+	display: grid;
+	gap: var(--space-1);
+}
+
+.copy p,
+.creator {
+	margin: 0;
+}
+
+.creator {
+	font-size: 0.95rem;
+	font-weight: var(--font-weight-medium);
+	color: var(--color-text-primary);
+}
+
+.topics {
+	list-style: none;
+	display: flex;
+	flex-wrap: wrap;
+	gap: 0.75rem;
+	margin: 0;
+	padding: 0;
+}
+
+.topics li {
+	padding: 0.4rem 0.75rem;
+	border-radius: 999px;
+	background: var(--color-library-topic-surface);
+	color: var(--color-library-topic-text);
+	font-size: 0.85rem;
+}
+
+@media (hover: hover) and (prefers-reduced-motion: no-preference) {
+	.card {
+		transition:
+			transform 180ms ease,
+			box-shadow 180ms ease;
+	}
+
+	.card:hover {
+		transform: translateY(-0.2rem);
+	}
+}
+
+@media (min-width: 48rem) {
+	.header {
+		grid-template-columns: minmax(0, 1fr) auto;
+	}
+
+	.grid {
+		grid-template-columns: repeat(2, minmax(0, 1fr));
+	}
+}

--- a/src/lib/organisms/library_shelf/LibraryShelf.module.css
+++ b/src/lib/organisms/library_shelf/LibraryShelf.module.css
@@ -1,96 +1,32 @@
-.shelf {
-	display: grid;
-	gap: var(--space-3);
-	padding: var(--space-4);
-	border: 1px solid var(--color-library-panel-border);
-	border-radius: 1.5rem;
-	background: var(--color-library-panel-surface);
-	box-shadow: var(--elevation-library-panel);
-}
-
-.header {
-	display: grid;
-	gap: var(--space-2);
-	align-items: end;
-}
-
-.header h2,
-.copy h3,
-.count {
-	margin: 0;
-}
-
-.header p {
-	margin: 0;
-	color: var(--color-library-panel-muted);
-}
-
-.count {
-	font-size: 0.95rem;
-	font-weight: var(--font-weight-semibold);
-	color: var(--color-library-chip-text);
-}
-
 .grid {
 	list-style: none;
 	display: grid;
 	grid-template-columns: repeat(1, minmax(0, 1fr));
 	gap: var(--space-3);
 	margin: 0;
-	padding: 0 0 var(--space-3);
-	position: relative;
-}
-
-.grid::after {
-	content: '';
-	position: absolute;
-	inset: auto 0 0;
-	height: 0.95rem;
-	border-radius: 999px;
-	background: linear-gradient(
-		180deg,
-		var(--color-library-shelf-rail-top),
-		var(--color-library-shelf-rail-bottom)
-	);
-	box-shadow: var(--elevation-library-rail);
+	padding: 0;
 }
 
 .item {
-	position: relative;
-	z-index: 1;
+	height: 100%;
 }
 
 .card {
 	display: grid;
 	gap: var(--space-2);
 	height: 100%;
-	padding: var(--space-3);
+	padding: var(--space-3) var(--space-3) calc(var(--space-3) + 0.15rem);
 	border: 1px solid var(--color-library-card-border);
 	border-radius: 1.15rem;
 	background: var(--color-library-card-surface);
 	box-shadow: var(--elevation-library-card);
-	position: relative;
-	overflow: hidden;
 }
 
-.card::before {
-	content: '';
-	position: absolute;
-	inset: 0 auto 0 0;
-	width: 0.55rem;
-	background: var(--color-library-accent-amber);
-}
-
-.cardSage::before {
-	background: var(--color-library-accent-sage);
-}
-
-.cardInk::before {
-	background: var(--color-library-accent-ink);
-}
-
-.cardRose::before {
-	background: var(--color-library-accent-rose);
+.header {
+	display: flex;
+	align-items: flex-start;
+	justify-content: space-between;
+	gap: var(--space-2);
 }
 
 .meta {
@@ -102,7 +38,7 @@
 	color: var(--color-library-card-meta);
 }
 
-.chip {
+.typeLabel {
 	display: inline-flex;
 	align-items: center;
 	padding: 0.3rem 0.7rem;
@@ -115,14 +51,43 @@
 	letter-spacing: 0.08em;
 }
 
+.iconBadge {
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+	flex-shrink: 0;
+	inline-size: 2.25rem;
+	block-size: 2.25rem;
+	border: 1px solid var(--color-library-icon-border);
+	border-radius: 999px;
+	background: var(--color-library-icon-surface);
+	color: var(--color-library-icon);
+}
+
+.icon {
+	inline-size: 1.1rem;
+	block-size: 1.1rem;
+	fill: none;
+	stroke: currentColor;
+	stroke-linecap: round;
+	stroke-linejoin: round;
+	stroke-width: 1.8;
+}
+
 .copy {
 	display: grid;
 	gap: var(--space-1);
 }
 
+.copy h3,
 .copy p,
 .creator {
 	margin: 0;
+}
+
+.copy h3 {
+	font-size: clamp(1.2rem, 2vw, 1.5rem);
+	line-height: 1.25;
 }
 
 .creator {
@@ -161,11 +126,13 @@
 }
 
 @media (min-width: 48rem) {
-	.header {
-		grid-template-columns: minmax(0, 1fr) auto;
-	}
-
 	.grid {
 		grid-template-columns: repeat(2, minmax(0, 1fr));
+	}
+}
+
+@media (min-width: 72rem) {
+	.grid {
+		grid-template-columns: repeat(3, minmax(0, 1fr));
 	}
 }

--- a/src/lib/organisms/library_shelf/LibraryShelf.svelte
+++ b/src/lib/organisms/library_shelf/LibraryShelf.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
-	import type { LibraryEntry } from '$lib/services/library/library';
+	import type { LibraryEntry, LibraryEntryAccent } from '$lib/services/library/library';
+	import styles from './LibraryShelf.module.css';
 
 	interface Props {
 		title: string;
@@ -12,34 +13,46 @@
 	function formatTopic(topic: string) {
 		return topic.replace(/\b\w/g, (character) => character.toUpperCase());
 	}
+
+	function createTitleId(value: string) {
+		return `library-shelf-${value.toLowerCase().replace(/\s+/g, '-')}`;
+	}
+
+	const titleId = $derived(createTitleId(title));
+	const accentClassByType: Record<LibraryEntryAccent, string> = {
+		amber: styles.cardAmber,
+		sage: styles.cardSage,
+		ink: styles.cardInk,
+		rose: styles.cardRose
+	};
 </script>
 
-<section class="library-shelf" aria-labelledby={`library-shelf-${title}`}>
-	<div class="library-shelf__header">
+<section class={styles.shelf} aria-labelledby={titleId}>
+	<div class={styles.header}>
 		<div>
-			<h2 id={`library-shelf-${title}`}>{title}</h2>
+			<h2 id={titleId}>{title}</h2>
 			<p>{description}</p>
 		</div>
-		<p class="library-shelf__count">{items.length} on this shelf</p>
+		<p class={styles.count}>{items.length} on this shelf</p>
 	</div>
 
-	<ul class="library-shelf__grid">
+	<ul class={styles.grid}>
 		{#each items as item (item.id)}
-			<li class="library-shelf__item">
-				<article class={`library-shelf__card library-shelf__card--${item.accent}`}>
-					<div class="library-shelf__meta">
-						<span class="library-shelf__chip">{item.type}</span>
+			<li class={styles.item}>
+				<article class={`${styles.card} ${accentClassByType[item.accent]}`}>
+					<div class={styles.meta}>
+						<span class={styles.chip}>{item.type}</span>
 						<span>{item.detail}</span>
 					</div>
 
-					<div class="library-shelf__copy">
+					<div class={styles.copy}>
 						<h3>{item.title}</h3>
 						<p>{item.summary}</p>
 					</div>
 
-					<p class="library-shelf__creator">{item.creator}</p>
+					<p class={styles.creator}>{item.creator}</p>
 
-					<ul class="library-shelf__topics" aria-label={`${item.title} topics`}>
+					<ul class={styles.topics} aria-label={`${item.title} topics`}>
 						{#each item.topics as topic (topic)}
 							<li>{formatTopic(topic)}</li>
 						{/each}
@@ -49,177 +62,3 @@
 		{/each}
 	</ul>
 </section>
-
-<style>
-	.library-shelf {
-		display: grid;
-		gap: var(--space-3);
-		padding: var(--space-4);
-		border: 1px solid var(--color-library-panel-border);
-		border-radius: 1.5rem;
-		background: var(--color-library-panel-surface);
-		box-shadow: var(--elevation-library-panel);
-	}
-
-	.library-shelf__header {
-		display: grid;
-		gap: var(--space-2);
-		align-items: end;
-	}
-
-	.library-shelf__header h2,
-	.library-shelf__copy h3,
-	.library-shelf__count {
-		margin: 0;
-	}
-
-	.library-shelf__header p {
-		margin: 0;
-		color: var(--color-library-panel-muted);
-	}
-
-	.library-shelf__count {
-		font-size: 0.95rem;
-		font-weight: var(--font-weight-semibold);
-		color: var(--color-library-chip-text);
-	}
-
-	.library-shelf__grid {
-		list-style: none;
-		display: grid;
-		grid-template-columns: repeat(1, minmax(0, 1fr));
-		gap: var(--space-3);
-		margin: 0;
-		padding: 0 0 var(--space-3);
-		position: relative;
-	}
-
-	.library-shelf__grid::after {
-		content: '';
-		position: absolute;
-		inset: auto 0 0;
-		height: 0.95rem;
-		border-radius: 999px;
-		background: linear-gradient(
-			180deg,
-			var(--color-library-shelf-rail-top),
-			var(--color-library-shelf-rail-bottom)
-		);
-		box-shadow: var(--elevation-library-rail);
-	}
-
-	.library-shelf__item {
-		position: relative;
-		z-index: 1;
-	}
-
-	.library-shelf__card {
-		display: grid;
-		gap: var(--space-2);
-		height: 100%;
-		padding: var(--space-3);
-		border: 1px solid var(--color-library-card-border);
-		border-radius: 1.15rem;
-		background: var(--color-library-card-surface);
-		box-shadow: var(--elevation-library-card);
-		position: relative;
-		overflow: hidden;
-	}
-
-	.library-shelf__card::before {
-		content: '';
-		position: absolute;
-		inset: 0 auto 0 0;
-		width: 0.55rem;
-		background: var(--color-library-accent-amber);
-	}
-
-	.library-shelf__card--sage::before {
-		background: var(--color-library-accent-sage);
-	}
-
-	.library-shelf__card--ink::before {
-		background: var(--color-library-accent-ink);
-	}
-
-	.library-shelf__card--rose::before {
-		background: var(--color-library-accent-rose);
-	}
-
-	.library-shelf__meta {
-		display: flex;
-		flex-wrap: wrap;
-		gap: var(--space-1);
-		align-items: center;
-		font-size: 0.9rem;
-		color: var(--color-library-card-meta);
-	}
-
-	.library-shelf__chip {
-		display: inline-flex;
-		align-items: center;
-		padding: 0.3rem 0.7rem;
-		border-radius: 999px;
-		background: var(--color-library-chip-surface);
-		color: var(--color-library-chip-text);
-		font-size: 0.8rem;
-		font-weight: var(--font-weight-semibold);
-		text-transform: uppercase;
-		letter-spacing: 0.08em;
-	}
-
-	.library-shelf__copy {
-		display: grid;
-		gap: var(--space-1);
-	}
-
-	.library-shelf__copy p,
-	.library-shelf__creator {
-		margin: 0;
-	}
-
-	.library-shelf__creator {
-		font-size: 0.95rem;
-		font-weight: var(--font-weight-medium);
-		color: var(--color-text-primary);
-	}
-
-	.library-shelf__topics {
-		list-style: none;
-		display: flex;
-		flex-wrap: wrap;
-		gap: 0.75rem;
-		margin: 0;
-		padding: 0;
-	}
-
-	.library-shelf__topics li {
-		padding: 0.4rem 0.75rem;
-		border-radius: 999px;
-		background: var(--color-library-topic-surface);
-		color: var(--color-library-topic-text);
-		font-size: 0.85rem;
-	}
-
-	@media (hover: hover) and (prefers-reduced-motion: no-preference) {
-		.library-shelf__card {
-			transition:
-				transform 180ms ease,
-				box-shadow 180ms ease;
-		}
-
-		.library-shelf__card:hover {
-			transform: translateY(-0.2rem);
-		}
-	}
-
-	@media (min-width: 48rem) {
-		.library-shelf__header {
-			grid-template-columns: minmax(0, 1fr) auto;
-		}
-
-		.library-shelf__grid {
-			grid-template-columns: repeat(2, minmax(0, 1fr));
-		}
-	}
-</style>

--- a/src/lib/organisms/library_shelf/LibraryShelf.svelte
+++ b/src/lib/organisms/library_shelf/LibraryShelf.svelte
@@ -1,64 +1,56 @@
 <script lang="ts">
-	import type { LibraryEntry, LibraryEntryAccent } from '$lib/services/library/library';
+	import type { LibraryEntry } from '$lib/services/library/library';
 	import styles from './LibraryShelf.module.css';
 
 	interface Props {
-		title: string;
-		description: string;
 		items: LibraryEntry[];
 	}
 
-	let { title, description, items }: Props = $props();
+	let { items }: Props = $props();
 
 	function formatTopic(topic: string) {
 		return topic.replace(/\b\w/g, (character) => character.toUpperCase());
 	}
-
-	function createTitleId(value: string) {
-		return `library-shelf-${value.toLowerCase().replace(/\s+/g, '-')}`;
-	}
-
-	const titleId = $derived(createTitleId(title));
-	const accentClassByType: Record<LibraryEntryAccent, string> = {
-		amber: styles.cardAmber,
-		sage: styles.cardSage,
-		ink: styles.cardInk,
-		rose: styles.cardRose
-	};
 </script>
 
-<section class={styles.shelf} aria-labelledby={titleId}>
-	<div class={styles.header}>
-		<div>
-			<h2 id={titleId}>{title}</h2>
-			<p>{description}</p>
-		</div>
-		<p class={styles.count}>{items.length} on this shelf</p>
-	</div>
-
-	<ul class={styles.grid}>
-		{#each items as item (item.id)}
-			<li class={styles.item}>
-				<article class={`${styles.card} ${accentClassByType[item.accent]}`}>
+<ul class={styles.grid} aria-label="Library entries">
+	{#each items as item (item.id)}
+		<li class={styles.item}>
+			<article class={styles.card}>
+				<div class={styles.header}>
 					<div class={styles.meta}>
-						<span class={styles.chip}>{item.type}</span>
+						<span class={styles.typeLabel}>{item.type}</span>
 						<span>{item.detail}</span>
 					</div>
+					<span class={styles.iconBadge} aria-label={`${item.type} recommendation`}>
+						{#if item.type === 'book'}
+							<svg viewBox="0 0 24 24" aria-hidden="true" focusable="false" class={styles.icon}>
+								<path
+									d="M12 6v12M4 7.5A2.5 2.5 0 0 1 6.5 5H11a3 3 0 0 1 3 3 3 3 0 0 1 3-3h4.5A2.5 2.5 0 0 1 24 7.5V19H17a5 5 0 0 0-5 5 5 5 0 0 0-5-5H0V7.5Z"
+								/>
+							</svg>
+						{:else}
+							<svg viewBox="0 0 24 24" aria-hidden="true" focusable="false" class={styles.icon}>
+								<path d="M4 5h13a3 3 0 0 1 3 3v11H7a3 3 0 0 1-3-3V5Z" />
+								<path d="M8 9h8M8 12h8M8 15h5M4 19a3 3 0 0 1-3-3V8" />
+							</svg>
+						{/if}
+					</span>
+				</div>
 
-					<div class={styles.copy}>
-						<h3>{item.title}</h3>
-						<p>{item.summary}</p>
-					</div>
+				<div class={styles.copy}>
+					<h3>{item.title}</h3>
+					<p>{item.summary}</p>
+				</div>
 
-					<p class={styles.creator}>{item.creator}</p>
+				<p class={styles.creator}>{item.creator}</p>
 
-					<ul class={styles.topics} aria-label={`${item.title} topics`}>
-						{#each item.topics as topic (topic)}
-							<li>{formatTopic(topic)}</li>
-						{/each}
-					</ul>
-				</article>
-			</li>
-		{/each}
-	</ul>
-</section>
+				<ul class={styles.topics} aria-label={`${item.title} topics`}>
+					{#each item.topics as topic (topic)}
+						<li>{formatTopic(topic)}</li>
+					{/each}
+				</ul>
+			</article>
+		</li>
+	{/each}
+</ul>

--- a/src/lib/organisms/library_shelf/LibraryShelf.svelte
+++ b/src/lib/organisms/library_shelf/LibraryShelf.svelte
@@ -1,4 +1,6 @@
 <script lang="ts">
+	import BookOpenText from '@lucide/svelte/icons/book-open-text';
+	import Newspaper from '@lucide/svelte/icons/newspaper';
 	import type { LibraryEntry } from '$lib/services/library/library';
 	import styles from './LibraryShelf.module.css';
 
@@ -22,18 +24,11 @@
 						<span class={styles.typeLabel}>{item.type}</span>
 						<span>{item.detail}</span>
 					</div>
-					<span class={styles.iconBadge} aria-label={`${item.type} recommendation`}>
+					<span class={styles.iconMarker} aria-label={`${item.type} recommendation`}>
 						{#if item.type === 'book'}
-							<svg viewBox="0 0 24 24" aria-hidden="true" focusable="false" class={styles.icon}>
-								<path
-									d="M12 6v12M4 7.5A2.5 2.5 0 0 1 6.5 5H11a3 3 0 0 1 3 3 3 3 0 0 1 3-3h4.5A2.5 2.5 0 0 1 24 7.5V19H17a5 5 0 0 0-5 5 5 5 0 0 0-5-5H0V7.5Z"
-								/>
-							</svg>
+							<BookOpenText class={styles.icon} aria-hidden="true" />
 						{:else}
-							<svg viewBox="0 0 24 24" aria-hidden="true" focusable="false" class={styles.icon}>
-								<path d="M4 5h13a3 3 0 0 1 3 3v11H7a3 3 0 0 1-3-3V5Z" />
-								<path d="M8 9h8M8 12h8M8 15h5M4 19a3 3 0 0 1-3-3V8" />
-							</svg>
+							<Newspaper class={styles.icon} aria-hidden="true" />
 						{/if}
 					</span>
 				</div>

--- a/src/lib/organisms/library_shelf/LibraryShelf.svelte
+++ b/src/lib/organisms/library_shelf/LibraryShelf.svelte
@@ -1,0 +1,225 @@
+<script lang="ts">
+	import type { LibraryEntry } from '$lib/services/library/library';
+
+	interface Props {
+		title: string;
+		description: string;
+		items: LibraryEntry[];
+	}
+
+	let { title, description, items }: Props = $props();
+
+	function formatTopic(topic: string) {
+		return topic.replace(/\b\w/g, (character) => character.toUpperCase());
+	}
+</script>
+
+<section class="library-shelf" aria-labelledby={`library-shelf-${title}`}>
+	<div class="library-shelf__header">
+		<div>
+			<h2 id={`library-shelf-${title}`}>{title}</h2>
+			<p>{description}</p>
+		</div>
+		<p class="library-shelf__count">{items.length} on this shelf</p>
+	</div>
+
+	<ul class="library-shelf__grid">
+		{#each items as item (item.id)}
+			<li class="library-shelf__item">
+				<article class={`library-shelf__card library-shelf__card--${item.accent}`}>
+					<div class="library-shelf__meta">
+						<span class="library-shelf__chip">{item.type}</span>
+						<span>{item.detail}</span>
+					</div>
+
+					<div class="library-shelf__copy">
+						<h3>{item.title}</h3>
+						<p>{item.summary}</p>
+					</div>
+
+					<p class="library-shelf__creator">{item.creator}</p>
+
+					<ul class="library-shelf__topics" aria-label={`${item.title} topics`}>
+						{#each item.topics as topic (topic)}
+							<li>{formatTopic(topic)}</li>
+						{/each}
+					</ul>
+				</article>
+			</li>
+		{/each}
+	</ul>
+</section>
+
+<style>
+	.library-shelf {
+		display: grid;
+		gap: var(--space-3);
+		padding: var(--space-4);
+		border: 1px solid var(--color-library-panel-border);
+		border-radius: 1.5rem;
+		background: var(--color-library-panel-surface);
+		box-shadow: var(--elevation-library-panel);
+	}
+
+	.library-shelf__header {
+		display: grid;
+		gap: var(--space-2);
+		align-items: end;
+	}
+
+	.library-shelf__header h2,
+	.library-shelf__copy h3,
+	.library-shelf__count {
+		margin: 0;
+	}
+
+	.library-shelf__header p {
+		margin: 0;
+		color: var(--color-library-panel-muted);
+	}
+
+	.library-shelf__count {
+		font-size: 0.95rem;
+		font-weight: var(--font-weight-semibold);
+		color: var(--color-library-chip-text);
+	}
+
+	.library-shelf__grid {
+		list-style: none;
+		display: grid;
+		grid-template-columns: repeat(1, minmax(0, 1fr));
+		gap: var(--space-3);
+		margin: 0;
+		padding: 0 0 var(--space-3);
+		position: relative;
+	}
+
+	.library-shelf__grid::after {
+		content: '';
+		position: absolute;
+		inset: auto 0 0;
+		height: 0.95rem;
+		border-radius: 999px;
+		background: linear-gradient(
+			180deg,
+			var(--color-library-shelf-rail-top),
+			var(--color-library-shelf-rail-bottom)
+		);
+		box-shadow: var(--elevation-library-rail);
+	}
+
+	.library-shelf__item {
+		position: relative;
+		z-index: 1;
+	}
+
+	.library-shelf__card {
+		display: grid;
+		gap: var(--space-2);
+		height: 100%;
+		padding: var(--space-3);
+		border: 1px solid var(--color-library-card-border);
+		border-radius: 1.15rem;
+		background: var(--color-library-card-surface);
+		box-shadow: var(--elevation-library-card);
+		position: relative;
+		overflow: hidden;
+	}
+
+	.library-shelf__card::before {
+		content: '';
+		position: absolute;
+		inset: 0 auto 0 0;
+		width: 0.55rem;
+		background: var(--color-library-accent-amber);
+	}
+
+	.library-shelf__card--sage::before {
+		background: var(--color-library-accent-sage);
+	}
+
+	.library-shelf__card--ink::before {
+		background: var(--color-library-accent-ink);
+	}
+
+	.library-shelf__card--rose::before {
+		background: var(--color-library-accent-rose);
+	}
+
+	.library-shelf__meta {
+		display: flex;
+		flex-wrap: wrap;
+		gap: var(--space-1);
+		align-items: center;
+		font-size: 0.9rem;
+		color: var(--color-library-card-meta);
+	}
+
+	.library-shelf__chip {
+		display: inline-flex;
+		align-items: center;
+		padding: 0.3rem 0.7rem;
+		border-radius: 999px;
+		background: var(--color-library-chip-surface);
+		color: var(--color-library-chip-text);
+		font-size: 0.8rem;
+		font-weight: var(--font-weight-semibold);
+		text-transform: uppercase;
+		letter-spacing: 0.08em;
+	}
+
+	.library-shelf__copy {
+		display: grid;
+		gap: var(--space-1);
+	}
+
+	.library-shelf__copy p,
+	.library-shelf__creator {
+		margin: 0;
+	}
+
+	.library-shelf__creator {
+		font-size: 0.95rem;
+		font-weight: var(--font-weight-medium);
+		color: var(--color-text-primary);
+	}
+
+	.library-shelf__topics {
+		list-style: none;
+		display: flex;
+		flex-wrap: wrap;
+		gap: 0.75rem;
+		margin: 0;
+		padding: 0;
+	}
+
+	.library-shelf__topics li {
+		padding: 0.4rem 0.75rem;
+		border-radius: 999px;
+		background: var(--color-library-topic-surface);
+		color: var(--color-library-topic-text);
+		font-size: 0.85rem;
+	}
+
+	@media (hover: hover) and (prefers-reduced-motion: no-preference) {
+		.library-shelf__card {
+			transition:
+				transform 180ms ease,
+				box-shadow 180ms ease;
+		}
+
+		.library-shelf__card:hover {
+			transform: translateY(-0.2rem);
+		}
+	}
+
+	@media (min-width: 48rem) {
+		.library-shelf__header {
+			grid-template-columns: minmax(0, 1fr) auto;
+		}
+
+		.library-shelf__grid {
+			grid-template-columns: repeat(2, minmax(0, 1fr));
+		}
+	}
+</style>

--- a/src/lib/services/library/library.ts
+++ b/src/lib/services/library/library.ts
@@ -1,5 +1,4 @@
 export type LibraryEntryType = 'book' | 'article';
-export type LibraryEntryAccent = 'amber' | 'sage' | 'ink' | 'rose';
 
 export interface LibraryEntry {
 	id: string;
@@ -9,7 +8,6 @@ export interface LibraryEntry {
 	type: LibraryEntryType;
 	topics: string[];
 	detail: string;
-	accent: LibraryEntryAccent;
 }
 
 export interface LibraryPageData {
@@ -30,8 +28,7 @@ const libraryEntries: LibraryEntry[] = [
 			'A reminder that strong facilitation is often a product decision, not just a meeting skill.',
 		type: 'book',
 		topics: ['leadership', 'facilitation', 'teamwork'],
-		detail: 'Book recommendation',
-		accent: 'amber'
+		detail: 'Book recommendation'
 	},
 	{
 		id: 'team-topologies',
@@ -41,8 +38,7 @@ const libraryEntries: LibraryEntry[] = [
 			'Useful for shaping team boundaries, reducing handoff drag, and making delivery architecture easier to evolve.',
 		type: 'book',
 		topics: ['engineering', 'systems', 'delivery'],
-		detail: 'Operating model',
-		accent: 'sage'
+		detail: 'Operating model'
 	},
 	{
 		id: 'thinking-in-systems',
@@ -52,8 +48,7 @@ const libraryEntries: LibraryEntry[] = [
 			'A steady guide for spotting leverage points before a roadmap turns into a pile of symptoms.',
 		type: 'book',
 		topics: ['strategy', 'systems', 'leadership'],
-		detail: 'Systems lens',
-		accent: 'ink'
+		detail: 'Systems lens'
 	},
 	{
 		id: 'designing-data-intensive-applications',
@@ -63,8 +58,7 @@ const libraryEntries: LibraryEntry[] = [
 			'Still one of the best references for making technical tradeoffs explicit when systems need to scale calmly.',
 		type: 'book',
 		topics: ['architecture', 'engineering', 'reliability'],
-		detail: 'Technical depth',
-		accent: 'rose'
+		detail: 'Technical depth'
 	},
 	{
 		id: 'library-article-roadmaps-bets',
@@ -74,8 +68,7 @@ const libraryEntries: LibraryEntry[] = [
 			'A field note on keeping direction clear without pretending every quarter can be planned at storyboard precision.',
 		type: 'article',
 		topics: ['strategy', 'leadership', 'delivery'],
-		detail: '6 min read',
-		accent: 'amber'
+		detail: '6 min read'
 	},
 	{
 		id: 'library-article-design-systems',
@@ -85,8 +78,7 @@ const libraryEntries: LibraryEntry[] = [
 			'Patterns for keeping components useful when product teams need speed, not a museum of polished examples.',
 		type: 'article',
 		topics: ['design systems', 'engineering', 'delivery'],
-		detail: '8 min read',
-		accent: 'ink'
+		detail: '8 min read'
 	},
 	{
 		id: 'library-article-manager-pace',
@@ -96,8 +88,7 @@ const libraryEntries: LibraryEntry[] = [
 			'A practical essay on creating clarity, trust, and momentum without turning every problem into urgency theatre.',
 		type: 'article',
 		topics: ['leadership', 'teamwork', 'career'],
-		detail: '5 min read',
-		accent: 'sage'
+		detail: '5 min read'
 	},
 	{
 		id: 'library-article-service-blueprints',
@@ -107,8 +98,7 @@ const libraryEntries: LibraryEntry[] = [
 			'An article about using service design artefacts as live delivery tools once the discovery deck has gone cold.',
 		type: 'article',
 		topics: ['design systems', 'facilitation', 'strategy'],
-		detail: '7 min read',
-		accent: 'rose'
+		detail: '7 min read'
 	}
 ];
 

--- a/src/lib/services/library/library.ts
+++ b/src/lib/services/library/library.ts
@@ -112,14 +112,14 @@ const libraryEntries: LibraryEntry[] = [
 	}
 ];
 
-export function getLibraryEntries(): LibraryEntry[] {
+function getLibraryEntries(): LibraryEntry[] {
 	return libraryEntries.map((entry) => ({
 		...entry,
 		topics: [...entry.topics]
 	}));
 }
 
-export function getLibraryTopics(entries: LibraryEntry[] = libraryEntries): string[] {
+function getLibraryTopics(entries: LibraryEntry[] = libraryEntries): string[] {
 	return Array.from(new Set(entries.flatMap((entry) => entry.topics))).sort((left, right) =>
 		left.localeCompare(right)
 	);

--- a/src/lib/services/library/library.ts
+++ b/src/lib/services/library/library.ts
@@ -1,0 +1,139 @@
+export type LibraryEntryType = 'book' | 'article';
+export type LibraryEntryAccent = 'amber' | 'sage' | 'ink' | 'rose';
+
+export interface LibraryEntry {
+	id: string;
+	title: string;
+	creator: string;
+	summary: string;
+	type: LibraryEntryType;
+	topics: string[];
+	detail: string;
+	accent: LibraryEntryAccent;
+}
+
+export interface LibraryPageData {
+	entries: LibraryEntry[];
+	topics: string[];
+	counts: {
+		books: number;
+		articles: number;
+	};
+}
+
+const libraryEntries: LibraryEntry[] = [
+	{
+		id: 'art-of-gathering',
+		title: 'The Art of Gathering',
+		creator: 'Priya Parker',
+		summary:
+			'A reminder that strong facilitation is often a product decision, not just a meeting skill.',
+		type: 'book',
+		topics: ['leadership', 'facilitation', 'teamwork'],
+		detail: 'Book recommendation',
+		accent: 'amber'
+	},
+	{
+		id: 'team-topologies',
+		title: 'Team Topologies',
+		creator: 'Matthew Skelton and Manuel Pais',
+		summary:
+			'Useful for shaping team boundaries, reducing handoff drag, and making delivery architecture easier to evolve.',
+		type: 'book',
+		topics: ['engineering', 'systems', 'delivery'],
+		detail: 'Operating model',
+		accent: 'sage'
+	},
+	{
+		id: 'thinking-in-systems',
+		title: 'Thinking in Systems',
+		creator: 'Donella Meadows',
+		summary:
+			'A steady guide for spotting leverage points before a roadmap turns into a pile of symptoms.',
+		type: 'book',
+		topics: ['strategy', 'systems', 'leadership'],
+		detail: 'Systems lens',
+		accent: 'ink'
+	},
+	{
+		id: 'designing-data-intensive-applications',
+		title: 'Designing Data-Intensive Applications',
+		creator: 'Martin Kleppmann',
+		summary:
+			'Still one of the best references for making technical tradeoffs explicit when systems need to scale calmly.',
+		type: 'book',
+		topics: ['architecture', 'engineering', 'reliability'],
+		detail: 'Technical depth',
+		accent: 'rose'
+	},
+	{
+		id: 'library-article-roadmaps-bets',
+		title: 'Roadmaps, bets, and the cost of false certainty',
+		creator: 'Chris I Powell',
+		summary:
+			'A field note on keeping direction clear without pretending every quarter can be planned at storyboard precision.',
+		type: 'article',
+		topics: ['strategy', 'leadership', 'delivery'],
+		detail: '6 min read',
+		accent: 'amber'
+	},
+	{
+		id: 'library-article-design-systems',
+		title: 'Design systems that survive delivery pressure',
+		creator: 'Chris I Powell',
+		summary:
+			'Patterns for keeping components useful when product teams need speed, not a museum of polished examples.',
+		type: 'article',
+		topics: ['design systems', 'engineering', 'delivery'],
+		detail: '8 min read',
+		accent: 'ink'
+	},
+	{
+		id: 'library-article-manager-pace',
+		title: 'What staff-plus leadership looks like at a humane pace',
+		creator: 'Chris I Powell',
+		summary:
+			'A practical essay on creating clarity, trust, and momentum without turning every problem into urgency theatre.',
+		type: 'article',
+		topics: ['leadership', 'teamwork', 'career'],
+		detail: '5 min read',
+		accent: 'sage'
+	},
+	{
+		id: 'library-article-service-blueprints',
+		title: 'Service blueprints for product teams, not just workshops',
+		creator: 'Chris I Powell',
+		summary:
+			'An article about using service design artefacts as live delivery tools once the discovery deck has gone cold.',
+		type: 'article',
+		topics: ['design systems', 'facilitation', 'strategy'],
+		detail: '7 min read',
+		accent: 'rose'
+	}
+];
+
+export function getLibraryEntries(): LibraryEntry[] {
+	return libraryEntries.map((entry) => ({
+		...entry,
+		topics: [...entry.topics]
+	}));
+}
+
+export function getLibraryTopics(entries: LibraryEntry[] = libraryEntries): string[] {
+	return Array.from(new Set(entries.flatMap((entry) => entry.topics))).sort((left, right) =>
+		left.localeCompare(right)
+	);
+}
+
+export function getLibraryPageData(): LibraryPageData {
+	const entries = getLibraryEntries();
+
+	return {
+		entries,
+		topics: getLibraryTopics(entries),
+		counts: {
+			books: entries.filter((entry) => entry.type === 'book').length,
+			articles: entries.filter((entry) => entry.type === 'article').length
+		}
+	};
+}

--- a/src/routes/library/+page.server.ts
+++ b/src/routes/library/+page.server.ts
@@ -1,0 +1,5 @@
+import { getLibraryPageData } from '$lib/services/library/library';
+
+export async function load() {
+	return getLibraryPageData();
+}

--- a/src/routes/library/+page.svelte
+++ b/src/routes/library/+page.svelte
@@ -1,107 +1,12 @@
 <script lang="ts">
-	import Container from '$lib/atoms/container/Container.svelte';
+	import LibraryExperience from '$lib/organisms/library_experience/LibraryExperience.svelte';
+	import type { LibraryPageData } from '$lib/services/library/library';
+
+	interface Props {
+		data: LibraryPageData;
+	}
+
+	let { data }: Props = $props();
 </script>
 
-<svelte:head>
-	<title>Chris I Powell - Library</title>
-	<meta
-		name="description"
-		content="A curated library of books and articles that have shaped Chris I Powell's taste, recommendations, and reading practice."
-	/>
-</svelte:head>
-
-<main class="library-page">
-	<Container maxWidth="narrow">
-		<div class="library-page__content">
-			<header class="library-page__intro">
-				<p class="library-page__eyebrow">Library</p>
-				<h1>A growing shelf of books and articles worth returning to.</h1>
-				<p class="library-page__lede">
-					Library is where I collect recommendations, references, and pieces that have stayed with
-					me. It is separate from <a href="/thoughts">Thoughts</a>: fewer essays from me, more
-					signals about what I value and keep coming back to.
-				</p>
-			</header>
-
-			<section class="library-page__section" aria-labelledby="books-heading">
-				<div class="library-page__section-header">
-					<p class="library-page__section-label">At launch</p>
-					<h2 id="books-heading">Books</h2>
-				</div>
-				<p>
-					Books in the Library will highlight the titles that have shaped how I think, lead, and
-					work. Over time, this can grow from a curated shelf into a fuller reading log without
-					changing the core structure of the section.
-				</p>
-			</section>
-
-			<section class="library-page__section" aria-labelledby="articles-heading">
-				<div class="library-page__section-header">
-					<p class="library-page__section-label">At launch</p>
-					<h2 id="articles-heading">Articles</h2>
-				</div>
-				<p>
-					Articles sit alongside books as the faster, more linkable side of the same practice:
-					sharing writing that is memorable, useful, or revealing. They belong in the same section
-					because the job is recommendation, not publication.
-				</p>
-			</section>
-
-			<section class="library-page__note" aria-labelledby="thoughts-heading">
-				<h2 id="thoughts-heading">How it relates to Thoughts</h2>
-				<p>
-					Thoughts remains the home for original writing and reflection. Library is the companion
-					space for what I am reading, citing, and recommending.
-				</p>
-			</section>
-		</div>
-	</Container>
-</main>
-
-<style>
-	.library-page {
-		padding-block: var(--space-5) var(--space-7);
-	}
-
-	.library-page__content {
-		display: grid;
-		gap: var(--space-4);
-	}
-
-	.library-page__intro,
-	.library-page__section,
-	.library-page__note {
-		display: grid;
-		gap: var(--space-2);
-	}
-
-	.library-page__section,
-	.library-page__note {
-		padding: var(--space-3);
-		border: 1px solid var(--color-divider-default);
-		border-radius: var(--space-2);
-		background: var(--color-surface-soft);
-	}
-
-	.library-page__eyebrow,
-	.library-page__section-label {
-		margin: 0;
-		font-family: var(--font-heading);
-		font-weight: var(--font-weight-medium);
-		letter-spacing: 0.06em;
-		text-transform: uppercase;
-	}
-
-	.library-page__lede,
-	.library-page__section p,
-	.library-page__note p {
-		margin: 0;
-		font-size: var(--font-size-body-lg);
-		line-height: var(--line-height-body);
-	}
-
-	.library-page__section-header {
-		display: grid;
-		gap: var(--space-1);
-	}
-</style>
+<LibraryExperience entries={data.entries} topics={data.topics} counts={data.counts} />


### PR DESCRIPTION
## Summary
- add a new `/library` route backed by a local library data service for curated books and articles
- build the `LibraryExperience` and `LibraryShelf` organisms with topic filtering, responsive shelf layouts, and Storybook coverage
- add library-specific design tokens in `src/lib/main.css` and document the experience in `docs/library-bookshelf-experience.md` and `README.md`

## Testing
- `npm run test:unit`
- `npm run check:types`
- `npm run build`