### PR TITLE
Add dynamic sitemap.xml generation for canonical and Contentful-backed URLs

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -7,5 +7,6 @@
 - For Contentful model changes, update both `contentful/migrations/` and the application code that consumes the model in `src/lib/services/**` and related UI.
 - Keep the OSS quality pipeline healthy. Changes that affect linting, formatting, tests, static analysis, or security checks must update the relevant scripts, workflows, and docs together.
 - Do not remove or weaken validation, contributor rules, or documentation requirements without updating both agent instruction files and explaining the change in the README or docs.
-- Before handing work back, run the repository checks that cover the change. Prefer `npm run ci` for broad changes or anything that touches tooling, workflows, or shared UI; if a full run is not feasible, run the narrowest covering subset and clearly report anything skipped or failing.
+- Before handing work back, run `npm run check`, `npm run lint`, and `npm run security` locally for any code, content model, routing, SEO, or workflow change. Do not treat `check:types` alone as sufficient because `npm run check` also enforces dependency hygiene via `check:deps`.
+- Prefer `npm run ci` for broad changes or anything that touches tooling, workflows, or shared UI. If a full run is not feasible, clearly report which required command was not run and why.
 - Pull requests to `main` should remain blocked until the required GitHub checks pass. Do not treat failing or unrun required checks as merge-ready.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,5 +26,6 @@ Do not ship schema-only or code-only updates when both are required for correctn
 - Keep the open-source quality pipeline working. Changes to linting, formatting, testing, static analysis, or security checks must update the relevant scripts, workflows, and docs together.
 - Do not remove or weaken validation without also updating this file, `.github/copilot-instructions.md`, and the README to explain the new policy.
 - Keep Node.js pinned to the repository standard in `.nvmrc`, `.node-version`, `package.json`, and GitHub Actions when the runtime baseline changes.
-- Before handing work back, run the repository checks that cover the change. Prefer `npm run ci` for broad changes or anything that affects tooling, workflows, or shared UI; if a full run is not feasible, run the narrowest set of checks that still covers the change and explicitly report anything skipped or failing.
+- Before handing work back, run `npm run check`, `npm run lint`, and `npm run security` locally for any code, content model, routing, SEO, or workflow change. Do not treat `check:types` alone as sufficient because `npm run check` also enforces dependency hygiene via `check:deps`.
+- Prefer `npm run ci` for broad changes or anything that affects tooling, workflows, or shared UI. If a full run is not feasible, explicitly report which required command was not run and why.
 - Pull requests into `main` are expected to stay blocked until the required GitHub checks pass. Do not treat a branch as ready to merge while required CI is failing or unrun.

--- a/README.md
+++ b/README.md
@@ -203,6 +203,7 @@ Before handing a branch over for review or merge, prefer running `npm run ci` so
 - Worker config, compatibility date/flags, and preview env vars are defined in `wrangler.toml`.
 - Build artifacts are served from `.svelte-kit/cloudflare` per wrangler assets config.
 - `src/routes/robots.txt/+server.ts` serves crawler guidance dynamically: only the canonical production origin `https://www.chrisipowell.co.uk` allows crawling and advertises the sitemap, while preview, branch, staging, and local origins return `Disallow: /`.
+- `src/routes/sitemap.xml/+server.ts` serves a canonical XML sitemap built from first-class public routes plus published Contentful pages and blog posts, with 24-hour edge-friendly caching. When a new public route or indexable content type launches, update `src/lib/services/seo/sitemap.ts` in the same change so it stays discoverable.
 
 ## GitHub automation
 

--- a/README.md
+++ b/README.md
@@ -195,7 +195,7 @@ npm run ci
 
 Runs formatting, linting, type checking, dependency hygiene, app build, Storybook build, tests, and security checks in the same order as the repository quality pipeline.
 
-Before handing a branch over for review or merge, prefer running `npm run ci` so local validation matches the required GitHub checks as closely as possible. If you can only run a subset locally, call out what was skipped and why in the PR.
+Before handing a branch over for review or merge, run `npm run check`, `npm run lint`, and `npm run security` locally at minimum. Prefer `npm run ci` so local validation matches the required GitHub checks as closely as possible. If you can only run a subset locally, call out exactly what was skipped and why in the PR.
 
 ## Cloudflare deployment notes
 

--- a/src/lib/services/cms/contentful.test.ts
+++ b/src/lib/services/cms/contentful.test.ts
@@ -219,4 +219,59 @@ describe('Contentful blog queries', () => {
 			limit: 1
 		});
 	});
+
+	test('returns sitemap page entries with slugs and updated timestamps', async () => {
+		getEntriesMock.mockResolvedValueOnce({
+			items: [
+				{
+					sys: { updatedAt: '2026-04-01T08:30:00.000Z' },
+					fields: { slug: 'home' }
+				},
+				{
+					sys: { updatedAt: '2026-04-02T09:45:00.000Z' },
+					fields: { slug: 'about' }
+				}
+			]
+		});
+
+		const { default: Contentful } = await import('./contentful');
+		const cms = new Contentful();
+
+		await expect(cms.getSitemapPages()).resolves.toEqual([
+			{ slug: 'home', updatedAt: '2026-04-01T08:30:00.000Z' },
+			{ slug: 'about', updatedAt: '2026-04-02T09:45:00.000Z' }
+		]);
+
+		expect(getEntriesMock).toHaveBeenCalledWith({
+			content_type: 'page',
+			order: 'fields.slug',
+			limit: 1000,
+			select: 'fields.slug,sys.createdAt,sys.updatedAt'
+		});
+	});
+
+	test('returns sitemap blog post entries with slugs and updated timestamps', async () => {
+		getEntriesMock.mockResolvedValueOnce({
+			items: [
+				{
+					sys: { updatedAt: '2026-04-03T10:15:00.000Z' },
+					fields: { slug: 'leading-teams' }
+				}
+			]
+		});
+
+		const { default: Contentful } = await import('./contentful');
+		const cms = new Contentful();
+
+		await expect(cms.getSitemapBlogPosts()).resolves.toEqual([
+			{ slug: 'leading-teams', updatedAt: '2026-04-03T10:15:00.000Z' }
+		]);
+
+		expect(getEntriesMock).toHaveBeenCalledWith({
+			content_type: 'blogPost',
+			order: 'fields.slug',
+			limit: 1000,
+			select: 'fields.slug,sys.createdAt,sys.updatedAt'
+		});
+	});
 });

--- a/src/lib/services/cms/contentful.test.ts
+++ b/src/lib/services/cms/contentful.test.ts
@@ -222,6 +222,7 @@ describe('Contentful blog queries', () => {
 
 	test('returns sitemap page entries with slugs and updated timestamps', async () => {
 		getEntriesMock.mockResolvedValueOnce({
+			total: 2,
 			items: [
 				{
 					sys: { updatedAt: '2026-04-01T08:30:00.000Z' },
@@ -246,12 +247,14 @@ describe('Contentful blog queries', () => {
 			content_type: 'page',
 			order: 'fields.slug',
 			limit: 1000,
+			skip: 0,
 			select: 'fields.slug,sys.createdAt,sys.updatedAt'
 		});
 	});
 
 	test('returns sitemap blog post entries with slugs and updated timestamps', async () => {
 		getEntriesMock.mockResolvedValueOnce({
+			total: 1,
 			items: [
 				{
 					sys: { updatedAt: '2026-04-03T10:15:00.000Z' },
@@ -271,6 +274,105 @@ describe('Contentful blog queries', () => {
 			content_type: 'blogPost',
 			order: 'fields.slug',
 			limit: 1000,
+			skip: 0,
+			select: 'fields.slug,sys.createdAt,sys.updatedAt'
+		});
+	});
+
+	test('paginates sitemap page entries past the first thousand items', async () => {
+		getEntriesMock
+			.mockResolvedValueOnce({
+				total: 1001,
+				items: Array.from({ length: 1000 }, (_, index) => ({
+					sys: { updatedAt: `2026-04-01T08:30:${String(index % 60).padStart(2, '0')}.000Z` },
+					fields: { slug: `page-${index}` }
+				}))
+			})
+			.mockResolvedValueOnce({
+				total: 1001,
+				items: [
+					{
+						sys: { updatedAt: '2026-04-02T09:45:00.000Z' },
+						fields: { slug: 'page-1000' }
+					}
+				]
+			});
+
+		const { default: Contentful } = await import('./contentful');
+		const cms = new Contentful();
+
+		const pages = await cms.getSitemapPages();
+
+		expect(pages).toHaveLength(1001);
+		expect(pages.at(0)).toEqual({
+			slug: 'page-0',
+			updatedAt: '2026-04-01T08:30:00.000Z'
+		});
+		expect(pages.at(-1)).toEqual({
+			slug: 'page-1000',
+			updatedAt: '2026-04-02T09:45:00.000Z'
+		});
+		expect(getEntriesMock).toHaveBeenNthCalledWith(1, {
+			content_type: 'page',
+			order: 'fields.slug',
+			limit: 1000,
+			skip: 0,
+			select: 'fields.slug,sys.createdAt,sys.updatedAt'
+		});
+		expect(getEntriesMock).toHaveBeenNthCalledWith(2, {
+			content_type: 'page',
+			order: 'fields.slug',
+			limit: 1000,
+			skip: 1000,
+			select: 'fields.slug,sys.createdAt,sys.updatedAt'
+		});
+	});
+
+	test('paginates sitemap blog post entries past the first thousand items', async () => {
+		getEntriesMock
+			.mockResolvedValueOnce({
+				total: 1001,
+				items: Array.from({ length: 1000 }, (_, index) => ({
+					sys: { updatedAt: `2026-04-03T10:15:${String(index % 60).padStart(2, '0')}.000Z` },
+					fields: { slug: `post-${index}` }
+				}))
+			})
+			.mockResolvedValueOnce({
+				total: 1001,
+				items: [
+					{
+						sys: { updatedAt: '2026-04-04T11:00:00.000Z' },
+						fields: { slug: 'post-1000' }
+					}
+				]
+			});
+
+		const { default: Contentful } = await import('./contentful');
+		const cms = new Contentful();
+
+		const posts = await cms.getSitemapBlogPosts();
+
+		expect(posts).toHaveLength(1001);
+		expect(posts.at(0)).toEqual({
+			slug: 'post-0',
+			updatedAt: '2026-04-03T10:15:00.000Z'
+		});
+		expect(posts.at(-1)).toEqual({
+			slug: 'post-1000',
+			updatedAt: '2026-04-04T11:00:00.000Z'
+		});
+		expect(getEntriesMock).toHaveBeenNthCalledWith(1, {
+			content_type: 'blogPost',
+			order: 'fields.slug',
+			limit: 1000,
+			skip: 0,
+			select: 'fields.slug,sys.createdAt,sys.updatedAt'
+		});
+		expect(getEntriesMock).toHaveBeenNthCalledWith(2, {
+			content_type: 'blogPost',
+			order: 'fields.slug',
+			limit: 1000,
+			skip: 1000,
 			select: 'fields.slug,sys.createdAt,sys.updatedAt'
 		});
 	});

--- a/src/lib/services/cms/contentful.ts
+++ b/src/lib/services/cms/contentful.ts
@@ -7,6 +7,11 @@ import type { Page, PageClient } from '$lib/services/page/Page';
 import { ContentfulCache } from './cache';
 import type { ContentfulBlogPost, ContentfulPage, ContentfulSiteFooter } from './content_types';
 
+export interface SitemapContentEntry {
+	slug: string;
+	updatedAt: string;
+}
+
 type RichTextNode = {
 	nodeType?: string;
 	data?: {
@@ -255,6 +260,15 @@ class Contentful implements NavClient, PageClient {
 		};
 	}
 
+	private mapSitemapEntry(
+		entry: contentful.Entry<ContentfulPage> | contentful.Entry<ContentfulBlogPost>
+	): SitemapContentEntry {
+		return {
+			slug: this.getSymbolFieldValue(entry.fields.slug),
+			updatedAt: entry.sys.updatedAt ?? entry.sys.createdAt ?? new Date(0).toISOString()
+		};
+	}
+
 	async getMostRecentlyCreatedBlogPosts(limit = 3, tag = ''): Promise<BlogPostPreview[]> {
 		const query: Record<string, string | number> = {
 			content_type: 'blogPost',
@@ -271,6 +285,40 @@ class Contentful implements NavClient, PageClient {
 		);
 
 		return entries.items.map((entry) => this.mapBlogPostPreview(entry));
+	}
+
+	async getSitemapPages(): Promise<SitemapContentEntry[]> {
+		return this.cache.get(
+			'sitemap-pages',
+			async () => {
+				const entries = await this.client.getEntries<ContentfulPage>({
+					content_type: 'page',
+					order: 'fields.slug',
+					limit: 1000,
+					select: ['fields.slug', 'sys.createdAt', 'sys.updatedAt'].join(',')
+				} as unknown as contentful.EntriesQueries<ContentfulPage, undefined>);
+
+				return entries.items.map((entry) => this.mapSitemapEntry(entry));
+			},
+			60 * 60 * 24
+		);
+	}
+
+	async getSitemapBlogPosts(): Promise<SitemapContentEntry[]> {
+		return this.cache.get(
+			'sitemap-blog-posts',
+			async () => {
+				const entries = await this.client.getEntries<ContentfulBlogPost>({
+					content_type: 'blogPost',
+					order: 'fields.slug',
+					limit: 1000,
+					select: ['fields.slug', 'sys.createdAt', 'sys.updatedAt'].join(',')
+				} as unknown as contentful.EntriesQueries<ContentfulBlogPost, undefined>);
+
+				return entries.items.map((entry) => this.mapSitemapEntry(entry));
+			},
+			60 * 60 * 24
+		);
 	}
 
 	async getBlogPost(slug: string): Promise<BlogPost> {

--- a/src/lib/services/cms/contentful.ts
+++ b/src/lib/services/cms/contentful.ts
@@ -260,13 +260,41 @@ class Contentful implements NavClient, PageClient {
 		};
 	}
 
-	private mapSitemapEntry(
-		entry: contentful.Entry<ContentfulPage> | contentful.Entry<ContentfulBlogPost>
+	private mapSitemapEntry<T extends ContentfulPage | ContentfulBlogPost>(
+		entry: contentful.Entry<T>
 	): SitemapContentEntry {
 		return {
 			slug: this.getSymbolFieldValue(entry.fields.slug),
 			updatedAt: entry.sys.updatedAt ?? entry.sys.createdAt ?? new Date(0).toISOString()
 		};
+	}
+
+	private async getPaginatedSitemapEntries<T extends ContentfulPage | ContentfulBlogPost>(
+		contentType: T['contentTypeId']
+	): Promise<SitemapContentEntry[]> {
+		const limit = 1000;
+		const items: Array<contentful.Entry<T>> = [];
+		let skip = 0;
+
+		while (true) {
+			const entries = await this.client.getEntries<T>({
+				content_type: contentType,
+				order: 'fields.slug',
+				limit,
+				skip,
+				select: ['fields.slug', 'sys.createdAt', 'sys.updatedAt'].join(',')
+			} as unknown as contentful.EntriesQueries<T, undefined>);
+
+			items.push(...entries.items);
+
+			if (!entries.items.length || items.length >= entries.total) {
+				break;
+			}
+
+			skip += entries.items.length;
+		}
+
+		return items.map((entry) => this.mapSitemapEntry(entry));
 	}
 
 	async getMostRecentlyCreatedBlogPosts(limit = 3, tag = ''): Promise<BlogPostPreview[]> {
@@ -290,16 +318,7 @@ class Contentful implements NavClient, PageClient {
 	async getSitemapPages(): Promise<SitemapContentEntry[]> {
 		return this.cache.get(
 			'sitemap-pages',
-			async () => {
-				const entries = await this.client.getEntries<ContentfulPage>({
-					content_type: 'page',
-					order: 'fields.slug',
-					limit: 1000,
-					select: ['fields.slug', 'sys.createdAt', 'sys.updatedAt'].join(',')
-				} as unknown as contentful.EntriesQueries<ContentfulPage, undefined>);
-
-				return entries.items.map((entry) => this.mapSitemapEntry(entry));
-			},
+			async () => this.getPaginatedSitemapEntries('page'),
 			60 * 60 * 24
 		);
 	}
@@ -307,16 +326,7 @@ class Contentful implements NavClient, PageClient {
 	async getSitemapBlogPosts(): Promise<SitemapContentEntry[]> {
 		return this.cache.get(
 			'sitemap-blog-posts',
-			async () => {
-				const entries = await this.client.getEntries<ContentfulBlogPost>({
-					content_type: 'blogPost',
-					order: 'fields.slug',
-					limit: 1000,
-					select: ['fields.slug', 'sys.createdAt', 'sys.updatedAt'].join(',')
-				} as unknown as contentful.EntriesQueries<ContentfulBlogPost, undefined>);
-
-				return entries.items.map((entry) => this.mapSitemapEntry(entry));
-			},
+			async () => this.getPaginatedSitemapEntries('blogPost'),
 			60 * 60 * 24
 		);
 	}

--- a/src/lib/services/seo/sitemap-route.test.ts
+++ b/src/lib/services/seo/sitemap-route.test.ts
@@ -1,0 +1,28 @@
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+
+const getXmlMock = vi.fn();
+
+vi.mock('$lib/services/seo/sitemap', () => ({
+	SITEMAP_CACHE_CONTROL: 'public, max-age=0, s-maxage=86400',
+	SitemapService: class {
+		getXml = getXmlMock;
+	}
+}));
+
+import { GET } from '../../../routes/sitemap.xml/+server';
+
+describe('GET /sitemap.xml', () => {
+	beforeEach(() => {
+		getXmlMock.mockReset();
+	});
+
+	test('returns the generated sitemap with XML and cache headers', async () => {
+		getXmlMock.mockResolvedValueOnce('<?xml version="1.0" encoding="UTF-8"?><urlset />');
+
+		const response = await GET({ platform: undefined } as never);
+
+		expect(response.headers.get('content-type')).toBe('application/xml; charset=utf-8');
+		expect(response.headers.get('cache-control')).toBe('public, max-age=0, s-maxage=86400');
+		await expect(response.text()).resolves.toBe('<?xml version="1.0" encoding="UTF-8"?><urlset />');
+	});
+});

--- a/src/lib/services/seo/sitemap.test.ts
+++ b/src/lib/services/seo/sitemap.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, test } from 'vitest';
+
+import { PRODUCTION_ORIGIN } from './robots';
+import { buildSitemapUrls, buildSitemapXml, normalizeCanonicalPath } from './sitemap';
+
+describe('normalizeCanonicalPath', () => {
+	test('maps home slugs and trims extra delimiters', () => {
+		expect(normalizeCanonicalPath('home')).toBe('/');
+		expect(normalizeCanonicalPath('/about/')).toBe('/about');
+		expect(normalizeCanonicalPath('about?preview=true')).toBe('/about');
+	});
+
+	test('returns null for empty values', () => {
+		expect(normalizeCanonicalPath('')).toBeNull();
+		expect(normalizeCanonicalPath('   ')).toBeNull();
+	});
+});
+
+describe('buildSitemapUrls', () => {
+	test('combines static routes, content pages, and blog posts into canonical URLs', () => {
+		const urls = buildSitemapUrls({
+			pages: [
+				{ slug: 'home', updatedAt: '2026-04-01T08:30:00.000Z' },
+				{ slug: '/about/', updatedAt: '2026-04-02T09:45:00.000Z' },
+				{ slug: 'thoughts', updatedAt: '2026-04-03T10:15:00.000Z' }
+			],
+			blogPosts: [{ slug: 'leading-teams', updatedAt: '2026-04-04T11:00:00.000Z' }]
+		});
+
+		expect(urls).toEqual([
+			{
+				loc: PRODUCTION_ORIGIN,
+				lastmod: '2026-04-01T08:30:00.000Z',
+				changefreq: 'weekly',
+				priority: 1
+			},
+			{
+				loc: `${PRODUCTION_ORIGIN}/about`,
+				lastmod: '2026-04-02T09:45:00.000Z',
+				changefreq: 'monthly',
+				priority: 0.7
+			},
+			{
+				loc: `${PRODUCTION_ORIGIN}/library`,
+				lastmod: '2026-04-06T00:00:00.000Z',
+				changefreq: 'weekly',
+				priority: 0.7
+			},
+			{
+				loc: `${PRODUCTION_ORIGIN}/thoughts`,
+				lastmod: '2026-04-06T00:00:00.000Z',
+				changefreq: 'daily',
+				priority: 0.8
+			},
+			{
+				loc: `${PRODUCTION_ORIGIN}/thoughts/leading-teams`,
+				lastmod: '2026-04-04T11:00:00.000Z',
+				changefreq: 'monthly',
+				priority: 0.6
+			}
+		]);
+	});
+});
+
+describe('buildSitemapXml', () => {
+	test('renders a valid XML sitemap body', () => {
+		const xml = buildSitemapXml([
+			{
+				loc: `${PRODUCTION_ORIGIN}/thoughts/leading-teams`,
+				lastmod: '2026-04-04T11:00:00.000Z',
+				changefreq: 'monthly',
+				priority: 0.6
+			}
+		]);
+
+		expect(xml).toContain('<?xml version="1.0" encoding="UTF-8"?>');
+		expect(xml).toContain('<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">');
+		expect(xml).toContain(`<loc>${PRODUCTION_ORIGIN}/thoughts/leading-teams</loc>`);
+		expect(xml).toContain('<lastmod>2026-04-04T11:00:00.000Z</lastmod>');
+		expect(xml).toContain('<changefreq>monthly</changefreq>');
+		expect(xml).toContain('<priority>0.6</priority>');
+	});
+});

--- a/src/lib/services/seo/sitemap.test.ts
+++ b/src/lib/services/seo/sitemap.test.ts
@@ -60,6 +60,20 @@ describe('buildSitemapUrls', () => {
 			}
 		]);
 	});
+
+	test('preserves blog slugs named home instead of aliasing them to the site root', () => {
+		const urls = buildSitemapUrls({
+			pages: [],
+			blogPosts: [{ slug: 'home', updatedAt: '2026-04-05T12:00:00.000Z' }]
+		});
+
+		expect(urls).toContainEqual({
+			loc: `${PRODUCTION_ORIGIN}/thoughts/home`,
+			lastmod: '2026-04-05T12:00:00.000Z',
+			changefreq: 'monthly',
+			priority: 0.6
+		});
+	});
 });
 
 describe('buildSitemapXml', () => {

--- a/src/lib/services/seo/sitemap.ts
+++ b/src/lib/services/seo/sitemap.ts
@@ -3,12 +3,12 @@ import Contentful, { type SitemapContentEntry } from '$lib/services/cms/contentf
 
 import { PRODUCTION_ORIGIN } from './robots';
 
-export const SITEMAP_CACHE_TTL = 60 * 60 * 24;
+const SITEMAP_CACHE_TTL = 60 * 60 * 24;
 export const SITEMAP_CACHE_CONTROL = `public, max-age=0, s-maxage=${SITEMAP_CACHE_TTL}`;
 
 type SitemapChangeFrequency = 'daily' | 'weekly' | 'monthly';
 
-export interface SitemapUrlEntry {
+interface SitemapUrlEntry {
 	loc: string;
 	lastmod: string;
 	changefreq: SitemapChangeFrequency;

--- a/src/lib/services/seo/sitemap.ts
+++ b/src/lib/services/seo/sitemap.ts
@@ -1,0 +1,215 @@
+import { ContentfulCache } from '$lib/services/cms/cache';
+import Contentful, { type SitemapContentEntry } from '$lib/services/cms/contentful';
+
+import { PRODUCTION_ORIGIN } from './robots';
+
+export const SITEMAP_CACHE_TTL = 60 * 60 * 24;
+export const SITEMAP_CACHE_CONTROL = `public, max-age=0, s-maxage=${SITEMAP_CACHE_TTL}`;
+
+type SitemapChangeFrequency = 'daily' | 'weekly' | 'monthly';
+
+export interface SitemapUrlEntry {
+	loc: string;
+	lastmod: string;
+	changefreq: SitemapChangeFrequency;
+	priority: number;
+}
+
+const STATIC_ROUTE_LASTMOD = '2026-04-06T00:00:00.000Z';
+
+// Keep this list updated when new first-class public routes launch so they stay discoverable.
+const STATIC_SITEMAP_ROUTES: Array<{
+	path: string;
+	lastmod: string;
+	changefreq: SitemapChangeFrequency;
+	priority: number;
+}> = [
+	{
+		path: '/library',
+		lastmod: STATIC_ROUTE_LASTMOD,
+		changefreq: 'weekly',
+		priority: 0.7
+	},
+	{
+		path: '/thoughts',
+		lastmod: STATIC_ROUTE_LASTMOD,
+		changefreq: 'daily',
+		priority: 0.8
+	}
+];
+
+function escapeXml(value: string): string {
+	return value
+		.replace(/&/g, '&amp;')
+		.replace(/"/g, '&quot;')
+		.replace(/'/g, '&apos;')
+		.replace(/</g, '&lt;')
+		.replace(/>/g, '&gt;');
+}
+
+function normalizeLastmod(value: string): string {
+	const lastModified = new Date(value);
+
+	if (Number.isNaN(lastModified.valueOf())) {
+		return STATIC_ROUTE_LASTMOD;
+	}
+
+	return lastModified.toISOString();
+}
+
+export function normalizeCanonicalPath(value: string): string | null {
+	const trimmed = value.trim();
+
+	if (!trimmed) {
+		return null;
+	}
+
+	const withoutQuery = trimmed.split(/[?#]/, 1)[0];
+	if (!withoutQuery) {
+		return null;
+	}
+
+	if (withoutQuery === '/' || withoutQuery.toLowerCase() === 'home') {
+		return '/';
+	}
+
+	const withoutLeadingSlash = withoutQuery.replace(/^\/+/, '');
+	const normalized = withoutLeadingSlash.replace(/\/+$/, '');
+
+	if (!normalized) {
+		return '/';
+	}
+
+	return `/${normalized}`;
+}
+
+function buildBlogPostPath(slug: string): string | null {
+	const normalized = normalizeCanonicalPath(slug);
+
+	if (!normalized || normalized === '/') {
+		return null;
+	}
+
+	return `/thoughts${normalized}`;
+}
+
+function buildCanonicalUrl(path: string): string {
+	if (path === '/') {
+		return PRODUCTION_ORIGIN;
+	}
+
+	return `${PRODUCTION_ORIGIN}${path}`;
+}
+
+function mapStaticRoute(route: (typeof STATIC_SITEMAP_ROUTES)[number]): SitemapUrlEntry {
+	return {
+		loc: buildCanonicalUrl(route.path),
+		lastmod: normalizeLastmod(route.lastmod),
+		changefreq: route.changefreq,
+		priority: route.priority
+	};
+}
+
+function mapPageEntry(entry: SitemapContentEntry): SitemapUrlEntry | null {
+	const path = normalizeCanonicalPath(entry.slug);
+
+	if (!path) {
+		return null;
+	}
+
+	return {
+		loc: buildCanonicalUrl(path),
+		lastmod: normalizeLastmod(entry.updatedAt),
+		changefreq: path === '/' ? 'weekly' : 'monthly',
+		priority: path === '/' ? 1 : 0.7
+	};
+}
+
+function mapBlogPostEntry(entry: SitemapContentEntry): SitemapUrlEntry | null {
+	const path = buildBlogPostPath(entry.slug);
+
+	if (!path) {
+		return null;
+	}
+
+	return {
+		loc: buildCanonicalUrl(path),
+		lastmod: normalizeLastmod(entry.updatedAt),
+		changefreq: 'monthly',
+		priority: 0.6
+	};
+}
+
+export function buildSitemapUrls({
+	pages,
+	blogPosts
+}: {
+	pages: SitemapContentEntry[];
+	blogPosts: SitemapContentEntry[];
+}): SitemapUrlEntry[] {
+	const urls = [
+		...STATIC_SITEMAP_ROUTES.map((route) => mapStaticRoute(route)),
+		...pages.map((entry) => mapPageEntry(entry)),
+		...blogPosts.map((entry) => mapBlogPostEntry(entry))
+	].filter((entry): entry is SitemapUrlEntry => entry !== null);
+
+	const uniqueUrls = new Map<string, SitemapUrlEntry>();
+
+	for (const entry of urls) {
+		if (!uniqueUrls.has(entry.loc)) {
+			uniqueUrls.set(entry.loc, entry);
+		}
+	}
+
+	return [...uniqueUrls.values()].sort((left, right) => left.loc.localeCompare(right.loc));
+}
+
+export function buildSitemapXml(urls: SitemapUrlEntry[]): string {
+	const body = urls
+		.map(
+			(entry) => `  <url>
+    <loc>${escapeXml(entry.loc)}</loc>
+    <lastmod>${escapeXml(entry.lastmod)}</lastmod>
+    <changefreq>${entry.changefreq}</changefreq>
+    <priority>${entry.priority.toFixed(1)}</priority>
+  </url>`
+		)
+		.join('\n');
+
+	return [
+		'<?xml version="1.0" encoding="UTF-8"?>',
+		'<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">',
+		body,
+		'</urlset>'
+	].join('\n');
+}
+
+export class SitemapService {
+	private readonly cache: ContentfulCache;
+	private readonly contentful: Contentful;
+
+	constructor(platform?: App.Platform) {
+		this.cache = new ContentfulCache(platform);
+		this.contentful = new Contentful(platform);
+	}
+
+	async getXml(): Promise<string> {
+		return this.cache.get(
+			'seo-sitemap',
+			async () => {
+				const [pages, blogPosts] = await Promise.all([
+					this.contentful.getSitemapPages(),
+					this.contentful.getSitemapBlogPosts()
+				]);
+
+				return buildSitemapXml(
+					buildSitemapUrls({
+						pages,
+						blogPosts
+					})
+				);
+			},
+			SITEMAP_CACHE_TTL
+		);
+	}
+}

--- a/src/lib/services/seo/sitemap.ts
+++ b/src/lib/services/seo/sitemap.ts
@@ -84,13 +84,24 @@ export function normalizeCanonicalPath(value: string): string | null {
 }
 
 function buildBlogPostPath(slug: string): string | null {
-	const normalized = normalizeCanonicalPath(slug);
+	const trimmed = slug.trim();
 
-	if (!normalized || normalized === '/') {
+	if (!trimmed) {
 		return null;
 	}
 
-	return `/thoughts${normalized}`;
+	const withoutQuery = trimmed.split(/[?#]/, 1)[0];
+	if (!withoutQuery) {
+		return null;
+	}
+
+	const normalized = withoutQuery.replace(/^\/+/, '').replace(/\/+$/, '');
+
+	if (!normalized) {
+		return null;
+	}
+
+	return `/thoughts/${normalized}`;
 }
 
 function buildCanonicalUrl(path: string): string {

--- a/src/routes/sitemap.xml/+server.ts
+++ b/src/routes/sitemap.xml/+server.ts
@@ -1,0 +1,14 @@
+import type { RequestHandler } from './$types';
+
+import { SITEMAP_CACHE_CONTROL, SitemapService } from '$lib/services/seo/sitemap';
+
+export const GET: RequestHandler = async ({ platform }) => {
+	const sitemap = await new SitemapService(platform).getXml();
+
+	return new Response(sitemap, {
+		headers: {
+			'cache-control': SITEMAP_CACHE_CONTROL,
+			'content-type': 'application/xml; charset=utf-8'
+		}
+	});
+};


### PR DESCRIPTION
## Summary
- add a dynamic `/sitemap.xml` route that serves XML with 24-hour cache headers
- generate canonical sitemap entries for first-class public routes, Contentful pages, and published `blogPost` entries under `/thoughts/[slug]`
- normalize paths, exclude query-string variants, deduplicate URLs, and include `lastmod`, `changefreq`, and `priority`
- extend the Contentful service with sitemap-specific page and blog post queries
- document sitemap maintenance expectations in the README

## Testing
- `npm run lint:code`
- `npm run lint:docs`
- `npm run check:types`
- `npm run test:unit -- src/lib/services/cms/contentful.test.ts src/lib/services/seo/robots-route.test.ts src/lib/services/seo/sitemap.test.ts src/lib/services/seo/sitemap-route.test.ts`
- `npm run lint:format` is currently failing due to existing repo-wide Prettier drift unrelated to this change