### PR TITLE
Add content-managed Library entries and pages

### DIFF
--- a/contentful/migrations/20260408000000-create-library-entry.cjs
+++ b/contentful/migrations/20260408000000-create-library-entry.cjs
@@ -1,0 +1,140 @@
+module.exports = function (migration) {
+	const libraryEntry = migration
+		.createContentType('libraryEntry')
+		.name('Library Entry')
+		.description('Shared library entry for books and articles surfaced on the Library pages')
+		.displayField('title');
+
+	libraryEntry
+		.createField('slug')
+		.name('Slug')
+		.type('Symbol')
+		.required(true)
+		.validations([{ unique: true }, { size: { min: 1, max: 120 } }]);
+
+	libraryEntry
+		.createField('title')
+		.name('Title')
+		.type('Symbol')
+		.required(true)
+		.validations([{ size: { min: 1, max: 160 } }]);
+
+	libraryEntry
+		.createField('format')
+		.name('Format')
+		.type('Symbol')
+		.required(true)
+		.defaultValue({ 'en-US': 'book' })
+		.validations([{ in: ['book', 'article'] }]);
+
+	libraryEntry
+		.createField('creatorText')
+		.name('Creator Text')
+		.type('Symbol')
+		.required(true)
+		.validations([{ size: { min: 1, max: 120 } }]);
+
+	libraryEntry
+		.createField('summary')
+		.name('Summary')
+		.type('Text')
+		.required(true)
+		.validations([{ size: { min: 1, max: 420 } }]);
+
+	libraryEntry
+		.createField('recommendationNote')
+		.name('Recommendation Note')
+		.type('Text')
+		.required(true)
+		.validations([{ size: { min: 1, max: 420 } }]);
+
+	libraryEntry
+		.createField('miniReview')
+		.name('Mini Review')
+		.type('Text')
+		.required(false)
+		.validations([{ size: { max: 420 } }]);
+
+	libraryEntry
+		.createField('publicationTitle')
+		.name('Publication Title')
+		.type('Symbol')
+		.required(false)
+		.validations([{ size: { max: 120 } }]);
+
+	libraryEntry.createField('publicationDate').name('Publication Date').type('Date').required(false);
+
+	libraryEntry
+		.createField('externalUrl')
+		.name('External URL')
+		.type('Symbol')
+		.required(false)
+		.validations([{ regexp: { pattern: '^(https?:\\/\\/|\\/).*', flags: '' } }]);
+
+	libraryEntry
+		.createField('coverOrThumbnail')
+		.name('Cover or Thumbnail')
+		.type('Link')
+		.linkType('Asset')
+		.required(false)
+		.validations([{ linkMimetypeGroup: ['image'] }]);
+
+	libraryEntry
+		.createField('topics')
+		.name('Topics')
+		.type('Array')
+		.required(false)
+		.items({
+			type: 'Symbol',
+			validations: [{ size: { min: 1, max: 40 } }]
+		})
+		.validations([{ size: { min: 0, max: 8 } }]);
+
+	libraryEntry
+		.createField('readingStatus')
+		.name('Reading Status')
+		.type('Symbol')
+		.required(false)
+		.validations([{ in: ['on-the-list', 'reading', 'finished'] }]);
+
+	libraryEntry.createField('startedOn').name('Started On').type('Date').required(false);
+
+	libraryEntry.createField('finishedOn').name('Finished On').type('Date').required(false);
+
+	libraryEntry
+		.createField('rating')
+		.name('Rating')
+		.type('Integer')
+		.required(false)
+		.validations([{ range: { min: 1, max: 5 } }]);
+
+	libraryEntry
+		.createField('notes')
+		.name('Notes')
+		.type('RichText')
+		.required(false)
+		.validations([
+			{
+				enabledNodeTypes: [
+					'heading-2',
+					'heading-3',
+					'ordered-list',
+					'unordered-list',
+					'blockquote',
+					'hr',
+					'hyperlink',
+					'entry-hyperlink',
+					'asset-hyperlink'
+				]
+			},
+			{
+				enabledMarks: ['bold', 'italic', 'underline', 'code']
+			},
+			{
+				nodes: {}
+			}
+		]);
+
+	libraryEntry.changeFieldControl('format', 'builtin', 'dropdown');
+	libraryEntry.changeFieldControl('readingStatus', 'builtin', 'dropdown');
+};

--- a/docs/library-information-architecture.md
+++ b/docs/library-information-architecture.md
@@ -6,7 +6,7 @@
 - `Library` exists to show taste, recommendations, and the body of work Chris returns to.
 - `Thoughts` remains the place for original writing, reflections, and essays.
 - Launch scope includes both books and articles.
-- Books and articles should share one content model so the section can mature into a fuller reading log without splitting the schema too early.
+- Books and articles share one content model so the section can mature into a fuller reading log without splitting the schema too early.
 
 ## Purpose and scope
 
@@ -27,7 +27,7 @@ That makes Library adjacent to Thoughts, but not a sub-section of it. Thoughts i
 
 ### What each level does
 
-- `/library` is the landing page for the section. It introduces the purpose of the Library and groups entries into `Books` and `Articles`.
+- `/library` is the landing page for the section. It introduces the purpose of the Library, supports topic filtering, and groups entries into `Books` and `Articles`.
 - `/library/[slug]` is the shared detail page pattern for individual entries, regardless of format.
 
 ### Relationship to Thoughts
@@ -62,21 +62,21 @@ If browsing needs grow later, additional views can be added without changing can
 - paginated archives
 - theme- or status-based reading log views
 
-## Shared entry model assumptions
+## Shared entry model
 
-Use one shared entry type, tentatively `libraryEntry`, for both books and articles.
+Use one shared entry type, `libraryEntry`, for both books and articles.
 
-### Required launch fields
+### Implemented launch fields
 
-- `internalName`
 - `slug`
 - `title`
 - `format` with launch values `book` and `article`
 - `creatorText`
 - `summary`
 - `recommendationNote`
+- `miniReview`
 
-### Optional launch fields
+### Optional launch fields currently supported
 
 - `publicationTitle`
 - `publicationDate`
@@ -86,7 +86,7 @@ Use one shared entry type, tentatively `libraryEntry`, for both books and articl
 
 ### Fields that prepare for a reading-log future
 
-- `readingStatus` such as `to-read`, `reading`, `finished`, `reference`
+- `readingStatus` as a Contentful dropdown with launch values `on-the-list`, `reading`, `finished`
 - `startedOn`
 - `finishedOn`
 - `rating`
@@ -103,4 +103,6 @@ Use one shared entry type, tentatively `libraryEntry`, for both books and articl
 
 - Navigation should expose `Library` as a first-class sibling of `Thoughts`.
 - The landing page should explain the distinction between original writing and recommendations.
-- Future Contentful work should add a dedicated `libraryEntry` model plus the supporting queries and page rendering needed for `/library/[slug]`.
+- Use `title` as the Contentful display field for `libraryEntry`; do not add a separate `internalName` for this model at launch.
+- The site now uses a dedicated `libraryEntry` Contentful model plus supporting queries for `/library` and `/library/[slug]`.
+- Topic filtering is currently powered by the shared `topics` field on `libraryEntry`, which keeps editorial control simple while preserving room for a richer taxonomy later.

--- a/src/lib/main.css
+++ b/src/lib/main.css
@@ -36,6 +36,23 @@
 	--color-cta-border-inverse: #bca6d0;
 	--color-cta-border-inverse-hover: #e0d2ef;
 	--color-cta-label-inverse: #f3e9ff;
+	--color-library-hero-surface: #efe8dc;
+	--color-library-note-surface: #fffaf2;
+	--color-library-note-border: #d7c8af;
+	--color-library-note-accent: #b48448;
+	--color-library-shelf-line: #c8b79f;
+	--color-library-book-surface: #fff8ef;
+	--color-library-article-surface: #f3f7fb;
+	--color-library-detail-surface: #f7f2ea;
+	--color-library-placeholder-surface: #f0e5d3;
+	--color-library-placeholder-border: #c9b28d;
+	--color-library-filter-surface: #fbf8ff;
+	--color-library-filter-surface-hover: #f0ebf6;
+	--color-library-filter-surface-active: #5a2e7d;
+	--color-library-filter-border: #cfc0dd;
+	--color-library-filter-border-active: #9b80b5;
+	--color-library-filter-text-active: #f5f3f7;
+	--color-library-meta-divider: #958377;
 
 	--footer-bg: var(--color-background);
 	--footer-bg-plum: var(--color-plum-600);

--- a/src/lib/organisms/library_experience/LibraryExperience.svelte
+++ b/src/lib/organisms/library_experience/LibraryExperience.svelte
@@ -1,11 +1,11 @@
-<script lang="ts">
+	<script lang="ts">
 	import Container from '$lib/atoms/container/Container.svelte';
 	import LibraryShelf from '$lib/organisms/library_shelf/LibraryShelf.svelte';
-	import type { LibraryEntry, LibraryEntryType } from '$lib/services/library/library';
+	import type { LibraryEntryType, LibraryShelfEntry } from '$lib/services/library/library';
 	import styles from './LibraryExperience.module.css';
 
 	interface Props {
-		entries: LibraryEntry[];
+		entries: LibraryShelfEntry[];
 		topics: string[];
 		counts: {
 			books: number;
@@ -38,8 +38,8 @@
 		activeTypes = [...activeTypes, type];
 	}
 
-	function interleaveEntries(books: LibraryEntry[], articles: LibraryEntry[]) {
-		const mixed: LibraryEntry[] = [];
+	function interleaveEntries(books: LibraryShelfEntry[], articles: LibraryShelfEntry[]) {
+		const mixed: LibraryShelfEntry[] = [];
 		const maxLength = Math.max(books.length, articles.length);
 
 		for (let index = 0; index < maxLength; index += 1) {

--- a/src/lib/organisms/library_experience/LibraryExperience.svelte
+++ b/src/lib/organisms/library_experience/LibraryExperience.svelte
@@ -1,4 +1,4 @@
-	<script lang="ts">
+<script lang="ts">
 	import Container from '$lib/atoms/container/Container.svelte';
 	import LibraryShelf from '$lib/organisms/library_shelf/LibraryShelf.svelte';
 	import type { LibraryEntryType, LibraryShelfEntry } from '$lib/services/library/library';

--- a/src/lib/organisms/library_shelf/LibraryShelf.module.css
+++ b/src/lib/organisms/library_shelf/LibraryShelf.module.css
@@ -14,11 +14,23 @@
 
 .card {
 	display: grid;
+	height: 100%;
+	border-top: 1px solid var(--color-library-card-border);
+	background: transparent;
+}
+
+.link {
+	display: grid;
 	gap: var(--space-2);
 	height: 100%;
 	padding-block: var(--space-3);
-	border-top: 1px solid var(--color-library-card-border);
-	background: transparent;
+	color: inherit;
+	text-decoration: none;
+}
+
+.link:hover,
+.link:focus-visible {
+	text-decoration: none;
 }
 
 .header {

--- a/src/lib/organisms/library_shelf/LibraryShelf.svelte
+++ b/src/lib/organisms/library_shelf/LibraryShelf.svelte
@@ -1,11 +1,11 @@
-<script lang="ts">
+	<script lang="ts">
 	import BookOpenText from '@lucide/svelte/icons/book-open-text';
 	import Newspaper from '@lucide/svelte/icons/newspaper';
-	import type { LibraryEntry } from '$lib/services/library/library';
+	import type { LibraryShelfEntry } from '$lib/services/library/library';
 	import styles from './LibraryShelf.module.css';
 
 	interface Props {
-		items: LibraryEntry[];
+		items: LibraryShelfEntry[];
 	}
 
 	let { items }: Props = $props();
@@ -19,32 +19,34 @@
 	{#each items as item (item.id)}
 		<li class={styles.item}>
 			<article class={styles.card}>
-				<div class={styles.header}>
-					<div class={styles.meta}>
-						<span class={styles.typeLabel}>{item.type}</span>
-						<span>{item.detail}</span>
+				<a class={styles.link} href={item.href} aria-label={`Open ${item.title}`}>
+					<div class={styles.header}>
+						<div class={styles.meta}>
+							<span class={styles.typeLabel}>{item.type}</span>
+							<span>{item.detail}</span>
+						</div>
+						<span class={styles.iconMarker} aria-label={`${item.type} recommendation`}>
+							{#if item.type === 'book'}
+								<BookOpenText class={styles.icon} aria-hidden="true" />
+							{:else}
+								<Newspaper class={styles.icon} aria-hidden="true" />
+							{/if}
+						</span>
 					</div>
-					<span class={styles.iconMarker} aria-label={`${item.type} recommendation`}>
-						{#if item.type === 'book'}
-							<BookOpenText class={styles.icon} aria-hidden="true" />
-						{:else}
-							<Newspaper class={styles.icon} aria-hidden="true" />
-						{/if}
-					</span>
-				</div>
 
-				<div class={styles.copy}>
-					<h3>{item.title}</h3>
-					<p>{item.summary}</p>
-				</div>
+					<div class={styles.copy}>
+						<h3>{item.title}</h3>
+						<p>{item.summary}</p>
+					</div>
 
-				<p class={styles.creator}>{item.creator}</p>
+					<p class={styles.creator}>{item.creator}</p>
 
-				<ul class={styles.topics} aria-label={`${item.title} topics`}>
-					{#each item.topics as topic (topic)}
-						<li>{formatTopic(topic)}</li>
-					{/each}
-				</ul>
+					<ul class={styles.topics} aria-label={`${item.title} topics`}>
+						{#each item.topics as topic (topic)}
+							<li>{formatTopic(topic)}</li>
+						{/each}
+					</ul>
+				</a>
 			</article>
 		</li>
 	{/each}

--- a/src/lib/organisms/library_shelf/LibraryShelf.svelte
+++ b/src/lib/organisms/library_shelf/LibraryShelf.svelte
@@ -1,4 +1,4 @@
-	<script lang="ts">
+<script lang="ts">
 	import BookOpenText from '@lucide/svelte/icons/book-open-text';
 	import Newspaper from '@lucide/svelte/icons/newspaper';
 	import type { LibraryShelfEntry } from '$lib/services/library/library';

--- a/src/lib/services/cms/content_types.d.ts
+++ b/src/lib/services/cms/content_types.d.ts
@@ -29,6 +29,29 @@ export type ContentfulBlogPreviewSection = {
 	};
 };
 
+export type ContentfulLibraryEntry = {
+	contentTypeId: 'libraryEntry';
+	fields: {
+		slug: EntryFieldTypes.Symbol;
+		title: EntryFieldTypes.Symbol;
+		format: EntryFieldTypes.Symbol<'book' | 'article'>;
+		creatorText: EntryFieldTypes.Symbol;
+		summary: EntryFieldTypes.Text;
+		recommendationNote: EntryFieldTypes.Text;
+		miniReview: EntryFieldTypes.Text;
+		publicationTitle: EntryFieldTypes.Symbol;
+		publicationDate: EntryFieldTypes.Date;
+		externalUrl: EntryFieldTypes.Symbol;
+		coverOrThumbnail: EntryFieldTypes.AssetLink;
+		topics: EntryFieldTypes.Array<EntryFieldTypes.Symbol>;
+		readingStatus: EntryFieldTypes.Symbol<'on-the-list' | 'reading' | 'finished'>;
+		startedOn: EntryFieldTypes.Date;
+		finishedOn: EntryFieldTypes.Date;
+		rating: EntryFieldTypes.Integer;
+		notes: EntryFieldTypes.RichText;
+	};
+};
+
 export type ContentfulFooterLink = {
 	contentTypeId: 'footerLink';
 	fields: {

--- a/src/lib/services/cms/contentful.test.ts
+++ b/src/lib/services/cms/contentful.test.ts
@@ -377,3 +377,153 @@ describe('Contentful blog queries', () => {
 		});
 	});
 });
+
+describe('Contentful library queries', () => {
+	beforeEach(() => {
+		vi.resetModules();
+		getEntriesMock.mockReset();
+		createClientMock.mockClear();
+		for (const key of Object.keys(envMock)) {
+			delete envMock[key];
+		}
+		envMock.CONTENTFUL_API_KEY = 'delivery-token';
+	});
+
+	test('returns library entries mapped from the shared libraryEntry content type', async () => {
+		getEntriesMock.mockResolvedValueOnce({
+			items: [
+				{
+					fields: {
+						title: 'An Elegant Puzzle',
+						slug: 'an-elegant-puzzle',
+						format: 'book',
+						creatorText: 'Will Larson',
+						summary: 'A management book for scaling engineering teams.',
+						recommendationNote:
+							'Useful whenever I need to reset how I think about org design.',
+						miniReview: 'Practical and opinionated in the right places.',
+						publicationTitle: '',
+						publicationDate: '2019-03-01',
+						externalUrl: '',
+						topics: ['leadership', 'engineering-management'],
+						readingStatus: 'finished',
+						startedOn: '2026-03-01',
+						finishedOn: '2026-03-12',
+						rating: 5,
+						coverOrThumbnail: {
+							fields: {
+								title: 'An Elegant Puzzle cover',
+								description: 'Book cover image',
+								file: {
+									url: '//images.ctfassets.net/library/book-cover.jpg'
+								}
+							}
+						}
+					}
+				}
+			]
+		});
+
+		const { default: Contentful } = await import('./contentful');
+		const cms = new Contentful();
+
+		await expect(cms.getLibraryEntries()).resolves.toEqual([
+			{
+				title: 'An Elegant Puzzle',
+				slug: 'an-elegant-puzzle',
+				format: 'book',
+				creatorText: 'Will Larson',
+				summary: 'A management book for scaling engineering teams.',
+				recommendationNote:
+					'Useful whenever I need to reset how I think about org design.',
+				miniReview: 'Practical and opinionated in the right places.',
+				publicationTitle: '',
+				publicationDate: '2019-03-01',
+				externalUrl: '',
+				topics: ['leadership', 'engineering-management'],
+				readingStatus: 'finished',
+				startedOn: '2026-03-01',
+				finishedOn: '2026-03-12',
+				rating: 5,
+				coverImage: {
+					url: 'https://images.ctfassets.net/library/book-cover.jpg',
+					title: 'An Elegant Puzzle cover',
+					description: 'Book cover image'
+				}
+			}
+		]);
+
+		expect(getEntriesMock).toHaveBeenCalledWith({
+			content_type: 'libraryEntry',
+			order: 'fields.format,-fields.publicationDate,fields.title',
+			include: 2
+		});
+	});
+
+	test('returns full library entry details for an individual slug', async () => {
+		getEntriesMock.mockResolvedValueOnce({
+			items: [
+				{
+					sys: { id: 'library-1', locale: 'en-US' },
+					fields: {
+						title: 'The Source Article',
+						slug: 'the-source-article',
+						format: 'article',
+						creatorText: 'Charity Majors',
+						summary: 'A sharp article about observability and feedback loops.',
+						recommendationNote: 'This one changed how I talk about systems work.',
+						miniReview: '',
+						publicationTitle: 'Honeycomb Blog',
+						publicationDate: '2024-11-05',
+						externalUrl: 'https://example.com/source-article',
+						topics: ['observability'],
+						readingStatus: 'on-the-list',
+						startedOn: '',
+						finishedOn: '',
+						rating: 4,
+						coverOrThumbnail: undefined,
+						notes: { nodeType: 'document', content: [] }
+					}
+				}
+			]
+		});
+
+		const { default: Contentful } = await import('./contentful');
+		const cms = new Contentful();
+
+		await expect(cms.getLibraryEntry('the-source-article')).resolves.toEqual({
+			title: 'The Source Article',
+			slug: 'the-source-article',
+			format: 'article',
+			creatorText: 'Charity Majors',
+			summary: 'A sharp article about observability and feedback loops.',
+			recommendationNote: 'This one changed how I talk about systems work.',
+			miniReview: '',
+			publicationTitle: 'Honeycomb Blog',
+			publicationDate: '2024-11-05',
+			externalUrl: 'https://example.com/source-article',
+			topics: ['observability'],
+			readingStatus: 'on-the-list',
+			startedOn: '',
+			finishedOn: '',
+			rating: 4,
+			coverImage: null,
+			notes: { nodeType: 'document', content: [] },
+			contentfulMetadata: {
+				entryId: 'library-1',
+				locale: 'en-US',
+				environment: 'master'
+			},
+			livePreview: {
+				enabled: false
+			}
+		});
+
+		expect(getEntriesMock).toHaveBeenCalledWith({
+			content_type: 'libraryEntry',
+			'fields.slug': 'the-source-article',
+			include: 2,
+			limit: 1
+		});
+	});
+});

--- a/src/lib/services/cms/contentful.test.ts
+++ b/src/lib/services/cms/contentful.test.ts
@@ -399,8 +399,7 @@ describe('Contentful library queries', () => {
 						format: 'book',
 						creatorText: 'Will Larson',
 						summary: 'A management book for scaling engineering teams.',
-						recommendationNote:
-							'Useful whenever I need to reset how I think about org design.',
+						recommendationNote: 'Useful whenever I need to reset how I think about org design.',
 						miniReview: 'Practical and opinionated in the right places.',
 						publicationTitle: '',
 						publicationDate: '2019-03-01',
@@ -434,8 +433,7 @@ describe('Contentful library queries', () => {
 				format: 'book',
 				creatorText: 'Will Larson',
 				summary: 'A management book for scaling engineering teams.',
-				recommendationNote:
-					'Useful whenever I need to reset how I think about org design.',
+				recommendationNote: 'Useful whenever I need to reset how I think about org design.',
 				miniReview: 'Practical and opinionated in the right places.',
 				publicationTitle: '',
 				publicationDate: '2019-03-01',

--- a/src/lib/services/cms/contentful.ts
+++ b/src/lib/services/cms/contentful.ts
@@ -1,11 +1,22 @@
 import { env } from '$env/dynamic/private';
 import type { BlogPost, BlogPostPreview } from '$lib/services/blog/Blog';
 import type { SiteFooterContent } from '$lib/services/footer/footer-content';
+import type {
+	LibraryEntry,
+	LibraryEntryPreview,
+	LibraryImage,
+	LibraryReadingStatus
+} from '$lib/services/library/library';
 import type { NavClient, NavLink } from '$lib/services/navigation/nav';
 import * as contentful from 'contentful';
 import type { Page, PageClient } from '$lib/services/page/Page';
 import { ContentfulCache } from './cache';
-import type { ContentfulBlogPost, ContentfulPage, ContentfulSiteFooter } from './content_types';
+import type {
+	ContentfulBlogPost,
+	ContentfulLibraryEntry,
+	ContentfulPage,
+	ContentfulSiteFooter
+} from './content_types';
 
 export interface SitemapContentEntry {
 	slug: string;
@@ -31,6 +42,19 @@ type RichTextNode = {
 		};
 	};
 	content?: RichTextNode[];
+};
+
+type RichTextDocument = { nodeType: string; content: unknown[] };
+type ContentfulAssetLike = {
+	fields?: {
+		title?: string | Record<string, string | undefined>;
+		description?: string | Record<string, string | undefined>;
+		file?:
+			| {
+					url?: string;
+			  }
+			| Record<string, { url?: string } | undefined>;
+	};
 };
 
 function mapResolvedFooterLinks(
@@ -96,10 +120,6 @@ class Contentful implements NavClient, PageClient {
 					query as unknown as contentful.EntriesQueries<ContentfulPage, undefined>
 				);
 
-				return pages.items.map((p) => ({
-					title: p.fields.title,
-					target: p.fields.slug
-				}));
 				return pages.items.map((p) => ({
 					title: p.fields.title,
 					target: p.fields.slug
@@ -215,7 +235,13 @@ class Contentful implements NavClient, PageClient {
 		return targets;
 	}
 
-	private getSymbolFieldValue(value: string | Record<string, string | undefined>): string {
+	private getSymbolFieldValue(
+		value: string | Record<string, string | undefined> | undefined
+	): string {
+		if (value === undefined) {
+			return '';
+		}
+
 		if (typeof value === 'string') {
 			return value;
 		}
@@ -250,6 +276,83 @@ class Contentful implements NavClient, PageClient {
 		}
 
 		return value?.['en-US'] ?? [];
+	}
+
+	private getDateFieldValue(value: string | Record<string, string | undefined> | undefined): string {
+		if (value === undefined) {
+			return '';
+		}
+
+		if (typeof value === 'string') {
+			return value;
+		}
+
+		return value['en-US'] ?? '';
+	}
+
+	private getIntegerFieldValue(
+		value: number | Record<string, number | undefined> | undefined
+	): number | null {
+		if (value === undefined) {
+			return null;
+		}
+
+		if (typeof value === 'number') {
+			return value;
+		}
+
+		return value['en-US'] ?? null;
+	}
+
+	private getAssetImage(asset: unknown): LibraryImage | null {
+		if (!asset || typeof asset !== 'object' || !('fields' in asset)) {
+			return null;
+		}
+
+		const resolvedAsset = asset as ContentfulAssetLike;
+		const fileField = resolvedAsset.fields?.file;
+		let url = '';
+		if (fileField && 'url' in fileField) {
+			url = (fileField as { url?: string }).url ?? '';
+		} else if (fileField) {
+			url =
+				(fileField as Record<string, { url?: string } | undefined>)['en-US']?.url ?? '';
+		}
+
+		if (!url) {
+			return null;
+		}
+
+		return {
+			url: url.startsWith('//') ? `https:${url}` : url,
+			title: this.getSymbolFieldValue(resolvedAsset.fields?.title),
+			description: this.getSymbolFieldValue(resolvedAsset.fields?.description)
+		};
+	}
+
+	private mapLibraryEntryPreview(
+		entry: contentful.Entry<ContentfulLibraryEntry>
+	): LibraryEntryPreview {
+		return {
+			title: this.getSymbolFieldValue(entry.fields.title),
+			slug: this.getSymbolFieldValue(entry.fields.slug),
+			format: this.getSymbolFieldValue(entry.fields.format) as LibraryEntryPreview['format'],
+			creatorText: this.getSymbolFieldValue(entry.fields.creatorText),
+			summary: this.getSymbolFieldValue(entry.fields.summary),
+			recommendationNote: this.getSymbolFieldValue(entry.fields.recommendationNote),
+			miniReview: this.getSymbolFieldValue(entry.fields.miniReview),
+			publicationTitle: this.getSymbolFieldValue(entry.fields.publicationTitle),
+			publicationDate: this.getDateFieldValue(entry.fields.publicationDate),
+			externalUrl: this.getSymbolFieldValue(entry.fields.externalUrl),
+			topics: this.getTagFieldValues(entry.fields.topics),
+			readingStatus: this.getSymbolFieldValue(
+				entry.fields.readingStatus
+			) as LibraryReadingStatus | '',
+			startedOn: this.getDateFieldValue(entry.fields.startedOn),
+			finishedOn: this.getDateFieldValue(entry.fields.finishedOn),
+			rating: this.getIntegerFieldValue(entry.fields.rating),
+			coverImage: this.getAssetImage(entry.fields.coverOrThumbnail)
+		};
 	}
 
 	private mapBlogPostPreview(entry: contentful.Entry<ContentfulBlogPost>): BlogPostPreview {
@@ -313,6 +416,55 @@ class Contentful implements NavClient, PageClient {
 		);
 
 		return entries.items.map((entry) => this.mapBlogPostPreview(entry));
+	}
+
+	async getLibraryEntries(): Promise<LibraryEntryPreview[]> {
+		return this.cache.get(
+			'library-entries',
+			async () => {
+				const entries = await this.client.getEntries<ContentfulLibraryEntry>({
+					content_type: 'libraryEntry',
+					order: 'fields.format,-fields.publicationDate,fields.title',
+					include: 2
+				} as unknown as contentful.EntriesQueries<ContentfulLibraryEntry, undefined>);
+
+				return entries.items.map((entry) => this.mapLibraryEntryPreview(entry));
+			},
+			60 * 60
+		);
+	}
+
+	async getLibraryEntry(slug: string): Promise<LibraryEntry> {
+		return this.cache.get(
+			`library-entry-${slug}`,
+			async () => {
+				const entries = await this.client.getEntries<ContentfulLibraryEntry>({
+					content_type: 'libraryEntry',
+					'fields.slug': slug,
+					include: 2,
+					limit: 1
+				} as unknown as contentful.EntriesQueries<ContentfulLibraryEntry, undefined>);
+
+				if (!entries.items.length) {
+					throw new Error(`Library entry not found: ${slug}`);
+				}
+
+				const entry = entries.items[0];
+				return {
+					...this.mapLibraryEntryPreview(entry),
+					notes: (entry.fields.notes as RichTextDocument | null | undefined) ?? null,
+					contentfulMetadata: {
+						entryId: entry.sys.id,
+						locale: entry.sys.locale || 'en-US',
+						environment: this.contentfulEnvironment
+					},
+					livePreview: {
+						enabled: this.previewEnabled
+					}
+				};
+			},
+			60 * 60
+		);
 	}
 
 	async getSitemapPages(): Promise<SitemapContentEntry[]> {

--- a/src/lib/services/cms/contentful.ts
+++ b/src/lib/services/cms/contentful.ts
@@ -278,7 +278,9 @@ class Contentful implements NavClient, PageClient {
 		return value?.['en-US'] ?? [];
 	}
 
-	private getDateFieldValue(value: string | Record<string, string | undefined> | undefined): string {
+	private getDateFieldValue(
+		value: string | Record<string, string | undefined> | undefined
+	): string {
 		if (value === undefined) {
 			return '';
 		}
@@ -315,8 +317,7 @@ class Contentful implements NavClient, PageClient {
 		if (fileField && 'url' in fileField) {
 			url = (fileField as { url?: string }).url ?? '';
 		} else if (fileField) {
-			url =
-				(fileField as Record<string, { url?: string } | undefined>)['en-US']?.url ?? '';
+			url = (fileField as Record<string, { url?: string } | undefined>)['en-US']?.url ?? '';
 		}
 
 		if (!url) {
@@ -345,9 +346,9 @@ class Contentful implements NavClient, PageClient {
 			publicationDate: this.getDateFieldValue(entry.fields.publicationDate),
 			externalUrl: this.getSymbolFieldValue(entry.fields.externalUrl),
 			topics: this.getTagFieldValues(entry.fields.topics),
-			readingStatus: this.getSymbolFieldValue(
-				entry.fields.readingStatus
-			) as LibraryReadingStatus | '',
+			readingStatus: this.getSymbolFieldValue(entry.fields.readingStatus) as
+				| LibraryReadingStatus
+				| '',
 			startedOn: this.getDateFieldValue(entry.fields.startedOn),
 			finishedOn: this.getDateFieldValue(entry.fields.finishedOn),
 			rating: this.getIntegerFieldValue(entry.fields.rating),

--- a/src/lib/services/library/library.ts
+++ b/src/lib/services/library/library.ts
@@ -1,6 +1,49 @@
 export type LibraryEntryType = 'book' | 'article';
+export type LibraryReadingStatus = 'on-the-list' | 'reading' | 'finished';
 
-export interface LibraryEntry {
+type RichTextDocument = {
+	nodeType: string;
+	content: unknown[];
+};
+
+export interface LibraryImage {
+	url: string;
+	title: string;
+	description: string;
+}
+
+export interface LibraryEntryPreview {
+	title: string;
+	slug: string;
+	format: LibraryEntryType;
+	creatorText: string;
+	summary: string;
+	recommendationNote: string;
+	miniReview: string;
+	publicationTitle: string;
+	publicationDate: string;
+	externalUrl: string;
+	topics: string[];
+	readingStatus: LibraryReadingStatus | '';
+	startedOn: string;
+	finishedOn: string;
+	rating: number | null;
+	coverImage: LibraryImage | null;
+}
+
+export interface LibraryEntry extends LibraryEntryPreview {
+	notes: RichTextDocument | null;
+	contentfulMetadata: {
+		entryId: string;
+		locale: string;
+		environment: string;
+	};
+	livePreview: {
+		enabled: boolean;
+	};
+}
+
+export interface LibraryShelfEntry {
 	id: string;
 	title: string;
 	creator: string;
@@ -8,10 +51,11 @@ export interface LibraryEntry {
 	type: LibraryEntryType;
 	topics: string[];
 	detail: string;
+	href: string;
 }
 
 export interface LibraryPageData {
-	entries: LibraryEntry[];
+	entries: LibraryShelfEntry[];
 	topics: string[];
 	counts: {
 		books: number;
@@ -19,7 +63,96 @@ export interface LibraryPageData {
 	};
 }
 
-const libraryEntries: LibraryEntry[] = [
+function cloneTopics(topics: string[]): string[] {
+	return [...topics];
+}
+
+export function formatLibraryReadingStatus(value: LibraryReadingStatus | ''): string {
+	if (!value) {
+		return '';
+	}
+
+	return value
+		.split('-')
+		.map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+		.join(' ');
+}
+
+function formatLibraryMonthYear(value: string): string {
+	if (!value) {
+		return '';
+	}
+
+	const date = new Date(value);
+	if (Number.isNaN(date.getTime())) {
+		return '';
+	}
+
+	return new Intl.DateTimeFormat('en-GB', {
+		month: 'short',
+		year: 'numeric'
+	}).format(date);
+}
+
+function getLibraryTopics(entries: Array<Pick<LibraryShelfEntry, 'topics'>>): string[] {
+	return Array.from(new Set(entries.flatMap((entry) => entry.topics))).sort((left, right) =>
+		left.localeCompare(right)
+	);
+}
+
+function countEntries(entries: LibraryShelfEntry[]): LibraryPageData['counts'] {
+	return {
+		books: entries.filter((entry) => entry.type === 'book').length,
+		articles: entries.filter((entry) => entry.type === 'article').length
+	};
+}
+
+export function getLibraryEntryDetail(
+	entry: Pick<
+		LibraryEntryPreview,
+		'format' | 'publicationTitle' | 'publicationDate' | 'readingStatus'
+	>
+): string {
+	if (entry.format === 'book') {
+		return (
+			formatLibraryReadingStatus(entry.readingStatus) ||
+			formatLibraryMonthYear(entry.publicationDate) ||
+			'Book recommendation'
+		);
+	}
+
+	return (
+		entry.publicationTitle ||
+		formatLibraryReadingStatus(entry.readingStatus) ||
+		formatLibraryMonthYear(entry.publicationDate) ||
+		'Article recommendation'
+	);
+}
+
+export function mapLibraryPreviewToShelfEntry(entry: LibraryEntryPreview): LibraryShelfEntry {
+	return {
+		id: entry.slug,
+		title: entry.title,
+		creator: entry.creatorText,
+		summary: entry.summary,
+		type: entry.format,
+		topics: cloneTopics(entry.topics),
+		detail: getLibraryEntryDetail(entry),
+		href: `/library/${entry.slug}`
+	};
+}
+
+export function createLibraryPageData(previewEntries: LibraryEntryPreview[]): LibraryPageData {
+	const entries = previewEntries.map((entry) => mapLibraryPreviewToShelfEntry(entry));
+
+	return {
+		entries,
+		topics: getLibraryTopics(entries),
+		counts: countEntries(entries)
+	};
+}
+
+const libraryEntries: LibraryShelfEntry[] = [
 	{
 		id: 'art-of-gathering',
 		title: 'The Art of Gathering',
@@ -28,7 +161,8 @@ const libraryEntries: LibraryEntry[] = [
 			'A reminder that strong facilitation is often a product decision, not just a meeting skill.',
 		type: 'book',
 		topics: ['leadership', 'facilitation', 'teamwork'],
-		detail: 'Book recommendation'
+		detail: 'Book recommendation',
+		href: '/library/art-of-gathering'
 	},
 	{
 		id: 'team-topologies',
@@ -38,7 +172,8 @@ const libraryEntries: LibraryEntry[] = [
 			'Useful for shaping team boundaries, reducing handoff drag, and making delivery architecture easier to evolve.',
 		type: 'book',
 		topics: ['engineering', 'systems', 'delivery'],
-		detail: 'Operating model'
+		detail: 'Operating model',
+		href: '/library/team-topologies'
 	},
 	{
 		id: 'thinking-in-systems',
@@ -48,7 +183,8 @@ const libraryEntries: LibraryEntry[] = [
 			'A steady guide for spotting leverage points before a roadmap turns into a pile of symptoms.',
 		type: 'book',
 		topics: ['strategy', 'systems', 'leadership'],
-		detail: 'Systems lens'
+		detail: 'Systems lens',
+		href: '/library/thinking-in-systems'
 	},
 	{
 		id: 'designing-data-intensive-applications',
@@ -58,7 +194,8 @@ const libraryEntries: LibraryEntry[] = [
 			'Still one of the best references for making technical tradeoffs explicit when systems need to scale calmly.',
 		type: 'book',
 		topics: ['architecture', 'engineering', 'reliability'],
-		detail: 'Technical depth'
+		detail: 'Technical depth',
+		href: '/library/designing-data-intensive-applications'
 	},
 	{
 		id: 'library-article-roadmaps-bets',
@@ -68,7 +205,8 @@ const libraryEntries: LibraryEntry[] = [
 			'A field note on keeping direction clear without pretending every quarter can be planned at storyboard precision.',
 		type: 'article',
 		topics: ['strategy', 'leadership', 'delivery'],
-		detail: '6 min read'
+		detail: '6 min read',
+		href: '/library/library-article-roadmaps-bets'
 	},
 	{
 		id: 'library-article-design-systems',
@@ -78,7 +216,8 @@ const libraryEntries: LibraryEntry[] = [
 			'Patterns for keeping components useful when product teams need speed, not a museum of polished examples.',
 		type: 'article',
 		topics: ['design systems', 'engineering', 'delivery'],
-		detail: '8 min read'
+		detail: '8 min read',
+		href: '/library/library-article-design-systems'
 	},
 	{
 		id: 'library-article-manager-pace',
@@ -88,7 +227,8 @@ const libraryEntries: LibraryEntry[] = [
 			'A practical essay on creating clarity, trust, and momentum without turning every problem into urgency theatre.',
 		type: 'article',
 		topics: ['leadership', 'teamwork', 'career'],
-		detail: '5 min read'
+		detail: '5 min read',
+		href: '/library/library-article-manager-pace'
 	},
 	{
 		id: 'library-article-service-blueprints',
@@ -98,32 +238,24 @@ const libraryEntries: LibraryEntry[] = [
 			'An article about using service design artefacts as live delivery tools once the discovery deck has gone cold.',
 		type: 'article',
 		topics: ['design systems', 'facilitation', 'strategy'],
-		detail: '7 min read'
+		detail: '7 min read',
+		href: '/library/library-article-service-blueprints'
 	}
 ];
 
-function getLibraryEntries(): LibraryEntry[] {
+function getSeedLibraryEntries(): LibraryShelfEntry[] {
 	return libraryEntries.map((entry) => ({
 		...entry,
-		topics: [...entry.topics]
+		topics: cloneTopics(entry.topics)
 	}));
 }
 
-function getLibraryTopics(entries: LibraryEntry[] = libraryEntries): string[] {
-	return Array.from(new Set(entries.flatMap((entry) => entry.topics))).sort((left, right) =>
-		left.localeCompare(right)
-	);
-}
-
 export function getLibraryPageData(): LibraryPageData {
-	const entries = getLibraryEntries();
+	const entries = getSeedLibraryEntries();
 
 	return {
 		entries,
 		topics: getLibraryTopics(entries),
-		counts: {
-			books: entries.filter((entry) => entry.type === 'book').length,
-			articles: entries.filter((entry) => entry.type === 'article').length
-		}
+		counts: countEntries(entries)
 	};
 }

--- a/src/lib/services/library/library.ts
+++ b/src/lib/services/library/library.ts
@@ -67,7 +67,7 @@ function cloneTopics(topics: string[]): string[] {
 	return [...topics];
 }
 
-export function formatLibraryReadingStatus(value: LibraryReadingStatus | ''): string {
+function formatLibraryReadingStatus(value: LibraryReadingStatus | ''): string {
 	if (!value) {
 		return '';
 	}
@@ -107,7 +107,7 @@ function countEntries(entries: LibraryShelfEntry[]): LibraryPageData['counts'] {
 	};
 }
 
-export function getLibraryEntryDetail(
+function getLibraryEntryDetail(
 	entry: Pick<
 		LibraryEntryPreview,
 		'format' | 'publicationTitle' | 'publicationDate' | 'readingStatus'
@@ -129,7 +129,7 @@ export function getLibraryEntryDetail(
 	);
 }
 
-export function mapLibraryPreviewToShelfEntry(entry: LibraryEntryPreview): LibraryShelfEntry {
+function mapLibraryPreviewToShelfEntry(entry: LibraryEntryPreview): LibraryShelfEntry {
 	return {
 		id: entry.slug,
 		title: entry.title,

--- a/src/routes/library/+page.server.ts
+++ b/src/routes/library/+page.server.ts
@@ -1,5 +1,9 @@
-import { getLibraryPageData } from '$lib/services/library/library';
+import Contentful from '$lib/services/cms/contentful';
+import { createLibraryPageData } from '$lib/services/library/library';
 
-export async function load() {
-	return getLibraryPageData();
+export async function load({ platform, url }) {
+	const preview = url.searchParams.get('preview') === 'true';
+	const contentful = new Contentful(platform, preview);
+	const entries = await contentful.getLibraryEntries();
+	return createLibraryPageData(entries);
 }

--- a/src/routes/library/[slug]/+page.server.ts
+++ b/src/routes/library/[slug]/+page.server.ts
@@ -1,0 +1,20 @@
+import type { LibraryEntry } from '$lib/services/library/library';
+import Contentful from '$lib/services/cms/contentful';
+import { error } from '@sveltejs/kit';
+
+export async function load({ params, platform, url }) {
+	const preview = url.searchParams.get('preview') === 'true';
+	const contentful = new Contentful(platform, preview);
+	let entry: LibraryEntry;
+
+	try {
+		entry = await contentful.getLibraryEntry(params.slug);
+	} catch (err) {
+		console.error(err);
+		throw error(404, {
+			message: 'Library entry not found'
+		});
+	}
+
+	return entry;
+}

--- a/src/routes/library/[slug]/+page.svelte
+++ b/src/routes/library/[slug]/+page.svelte
@@ -1,0 +1,333 @@
+<script lang="ts">
+	import { invalidateAll } from '$app/navigation';
+	import Container from '$lib/atoms/container/Container.svelte';
+	import ContentfulRichText from '$lib/organisms/rich_text/ContentfulRichText.svelte';
+	import { ContentfulLivePreview } from '@contentful/live-preview';
+	import { onMount } from 'svelte';
+
+	interface Props {
+		data: {
+			title: string;
+			slug: string;
+			format: 'book' | 'article';
+			creatorText: string;
+			summary: string;
+			recommendationNote: string;
+			miniReview: string;
+			publicationTitle: string;
+			publicationDate: string;
+			externalUrl: string;
+			topics: string[];
+			readingStatus: string;
+			startedOn: string;
+			finishedOn: string;
+			rating: number | null;
+			coverImage: {
+				url: string;
+				title: string;
+				description: string;
+			} | null;
+			notes: { nodeType: string; content: unknown[] } | null;
+			contentfulMetadata: {
+				entryId: string;
+				locale: string;
+			};
+			livePreview: {
+				enabled: boolean;
+			};
+		};
+	}
+
+	let { data }: Props = $props();
+	const notes = $derived(data.notes);
+
+	function formatDate(value: string): string {
+		if (!value) {
+			return '';
+		}
+
+		return new Intl.DateTimeFormat('en-GB', {
+			day: 'numeric',
+			month: 'long',
+			year: 'numeric'
+		}).format(new Date(value));
+	}
+
+	function formatReadingStatus(value: string): string {
+		if (!value) {
+			return '';
+		}
+
+		return value
+			.split('-')
+			.map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+			.join(' ');
+	}
+
+	onMount(() => {
+		if (!data.livePreview.enabled) {
+			return;
+		}
+
+		let unsubscribe: (() => void) | undefined;
+		let cancelled = false;
+		let refreshInFlight = false;
+
+		const subscribeAfterInit = async () => {
+			while (!ContentfulLivePreview.initialized && !cancelled) {
+				await new Promise((resolve) => setTimeout(resolve, 50));
+			}
+
+			if (cancelled) {
+				return;
+			}
+
+			unsubscribe = ContentfulLivePreview.subscribe('save', {
+				callback: async () => {
+					if (refreshInFlight) {
+						return;
+					}
+
+					refreshInFlight = true;
+					try {
+						await invalidateAll();
+					} finally {
+						refreshInFlight = false;
+					}
+				}
+			});
+		};
+
+		void subscribeAfterInit();
+
+		return () => {
+			cancelled = true;
+			unsubscribe?.();
+		};
+	});
+</script>
+
+<svelte:head>
+	<title>Chris I Powell - {data.title}</title>
+</svelte:head>
+
+<main class="library-entry-page">
+	<Container maxWidth="narrow">
+		<article class="library-entry" data-contentful-entry-id={data.contentfulMetadata.entryId}>
+			<a class="library-entry__back-link" href="/library">Back to library</a>
+
+			<div class="library-entry__hero">
+				{#if data.coverImage}
+					<img
+						class="library-entry__cover"
+						src={data.coverImage.url}
+						alt={data.coverImage.description || `${data.title} cover image`}
+					/>
+				{/if}
+
+				<div class="library-entry__hero-copy">
+					<p class="library-entry__eyebrow">{data.format === 'book' ? 'Book' : 'Article'}</p>
+					<h1
+						data-contentful-field-id="title"
+						data-contentful-locale={data.contentfulMetadata.locale}
+					>
+						{data.title}
+					</h1>
+					<p class="library-entry__creator">{data.creatorText}</p>
+
+					<ul class="library-entry__meta" aria-label="Library entry metadata">
+						{#if data.publicationTitle}
+							<li>{data.publicationTitle}</li>
+						{/if}
+						{#if data.publicationDate}
+							<li>{formatDate(data.publicationDate)}</li>
+						{/if}
+						{#if data.readingStatus}
+							<li>{formatReadingStatus(data.readingStatus)}</li>
+						{/if}
+						{#if data.rating}
+							<li>{data.rating}/5</li>
+						{/if}
+					</ul>
+
+					{#if data.topics.length}
+						<ul class="library-entry__topics" aria-label="Library topics">
+							{#each data.topics as topic (topic)}
+								<li>{topic}</li>
+							{/each}
+						</ul>
+					{/if}
+
+					{#if data.externalUrl}
+						<p>
+							<a href={data.externalUrl} target="_blank" rel="noreferrer">Visit original source</a>
+						</p>
+					{/if}
+				</div>
+			</div>
+
+			<section class="library-entry__section">
+				<p class="library-entry__section-label">Summary</p>
+				<p
+					class="library-entry__lead"
+					data-contentful-field-id="summary"
+					data-contentful-locale={data.contentfulMetadata.locale}
+				>
+					{data.summary}
+				</p>
+			</section>
+
+			<section class="library-entry__section">
+				<p class="library-entry__section-label">Why it stays with me</p>
+				<p
+					class="library-entry__callout"
+					data-contentful-field-id="recommendationNote"
+					data-contentful-locale={data.contentfulMetadata.locale}
+				>
+					{data.recommendationNote}
+				</p>
+			</section>
+
+			{#if data.miniReview}
+				<section class="library-entry__section">
+					<p class="library-entry__section-label">Mini review</p>
+					<p
+						data-contentful-field-id="miniReview"
+						data-contentful-locale={data.contentfulMetadata.locale}
+					>
+						{data.miniReview}
+					</p>
+				</section>
+			{/if}
+
+			{#if data.startedOn || data.finishedOn}
+				<section class="library-entry__section">
+					<p class="library-entry__section-label">Reading log</p>
+					<div class="library-entry__dates">
+						{#if data.startedOn}
+							<p><strong>Started:</strong> {formatDate(data.startedOn)}</p>
+						{/if}
+						{#if data.finishedOn}
+							<p><strong>Finished:</strong> {formatDate(data.finishedOn)}</p>
+						{/if}
+					</div>
+				</section>
+			{/if}
+
+			{#if notes}
+				<section
+					class="library-entry__section library-entry__notes"
+					data-contentful-field-id="notes"
+					data-contentful-locale={data.contentfulMetadata.locale}
+				>
+					<p class="library-entry__section-label">Notes</p>
+					<ContentfulRichText document={notes} />
+				</section>
+			{/if}
+		</article>
+	</Container>
+</main>
+
+<style>
+	.library-entry-page {
+		padding-block: var(--space-5) var(--space-7);
+	}
+
+	.library-entry {
+		display: grid;
+		gap: var(--space-4);
+	}
+
+	.library-entry__back-link {
+		font-family: var(--font-heading);
+		font-weight: var(--font-weight-medium);
+	}
+
+	.library-entry__hero {
+		display: grid;
+		gap: var(--space-3);
+		align-items: start;
+		padding: var(--space-4);
+		border: 1px solid var(--color-divider-default);
+		border-radius: var(--space-3);
+		background: var(--color-library-detail-surface);
+	}
+
+	.library-entry__cover {
+		float: none;
+		width: 100%;
+		max-height: none;
+		margin: 0;
+		border-radius: var(--space-2);
+		object-fit: cover;
+		aspect-ratio: 4 / 5;
+	}
+
+	.library-entry__hero-copy,
+	.library-entry__section {
+		display: grid;
+		gap: var(--space-2);
+	}
+
+	.library-entry__eyebrow,
+	.library-entry__section-label {
+		margin: 0;
+		font-family: var(--font-heading);
+		font-weight: var(--font-weight-medium);
+		letter-spacing: 0.06em;
+		text-transform: uppercase;
+	}
+
+	.library-entry__creator,
+	.library-entry__lead,
+	.library-entry__callout,
+	.library-entry__dates p,
+	.library-entry__section :global(p),
+	.library-entry__section :global(li),
+	.library-entry__section :global(blockquote) {
+		margin: 0;
+		font-size: var(--font-size-body-lg);
+		line-height: var(--line-height-body);
+	}
+
+	.library-entry__callout {
+		padding-left: var(--space-2);
+		border-left: 3px solid var(--color-library-note-accent);
+		font-family: var(--font-heading);
+	}
+
+	.library-entry__meta,
+	.library-entry__topics {
+		display: flex;
+		flex-wrap: wrap;
+		gap: var(--space-1);
+		margin: 0;
+		padding: 0;
+		list-style: none;
+	}
+
+	.library-entry__meta li,
+	.library-entry__topics li {
+		padding: calc(var(--space-1) * 0.75) var(--space-2);
+		border-radius: var(--space-4);
+		background: var(--color-library-filter-surface);
+	}
+
+	.library-entry__section {
+		padding: var(--space-3);
+		border: 1px solid var(--color-divider-default);
+		border-radius: var(--space-3);
+		background: var(--color-surface-default);
+	}
+
+	.library-entry__notes :global(ul),
+	.library-entry__notes :global(ol) {
+		padding-left: 1.25rem;
+	}
+
+	@media (min-width: 48rem) {
+		.library-entry__hero {
+			grid-template-columns: minmax(12rem, 16rem) minmax(0, 1fr);
+		}
+	}
+</style>


### PR DESCRIPTION
## Summary
- add a shared Contentful `libraryEntry` model for books and articles
- implement CMS types, fetching, and tests for Library entries and detail pages
- replace the Library placeholder with content-managed listing, filtering, and entry routes
- add Library-specific styling tokens and update the information architecture doc

## Testing
- `npm run check:types`
- `npm run lint:code`
- `npm run lint:docs`
- `npm run build`
- `npm run test:unit -- src/lib/services/cms/contentful.test.ts`