### PR TITLE
[codex] Add suspicious path guard

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,6 +202,7 @@ Before handing a branch over for review or merge, run `npm run check`, `npm run 
 - SvelteKit is configured with Cloudflare adapter in `svelte.config.js`.
 - Worker config, compatibility date/flags, and preview env vars are defined in `wrangler.toml`.
 - Build artifacts are served from `.svelte-kit/cloudflare` per wrangler assets config.
+- `src/hooks.server.ts` blocks high-volume probe paths (`*.php`, `/wp-*`, and `/xmlrpc.php`) early in the request lifecycle with a low-information `404 Not Found` response, and emits sampled warning logs with request metadata for observability.
 - `src/routes/robots.txt/+server.ts` serves crawler guidance dynamically: only the canonical production origin `https://www.chrisipowell.co.uk` allows crawling and advertises the sitemap, while preview, branch, staging, and local origins return `Disallow: /`.
 - `src/routes/sitemap.xml/+server.ts` serves a canonical XML sitemap built from first-class public routes plus published Contentful pages and blog posts, with 24-hour edge-friendly caching. When a new public route or indexable content type launches, update `src/lib/services/seo/sitemap.ts` in the same change so it stays discoverable.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -8299,9 +8299,9 @@
 			}
 		},
 		"node_modules/postcss": {
-			"version": "8.5.8",
-			"resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.8.tgz",
-			"integrity": "sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==",
+			"version": "8.5.11",
+			"resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.11.tgz",
+			"integrity": "sha512-5dDj8+lmvA8XB78SmzGI8NlQoksv7IfutGWeVZxiixHbO+p4LDPT3wuG/D9sM/wrjZZ9I+Siy/e117vbFPxSZg==",
 			"dev": true,
 			"funding": [
 				{

--- a/src/hooks.server.test.ts
+++ b/src/hooks.server.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import {
+	getSuspiciousPathReason,
+	handle,
+	isSuspiciousPath,
+	shouldSampleSuspiciousLog
+} from './hooks.server';
+
+describe('getSuspiciousPathReason', () => {
+	it('returns specific reason for xmlrpc path before generic php match', () => {
+		expect(getSuspiciousPathReason('/xmlrpc.php')).toBe('xmlrpc-endpoint');
+	});
+
+	it('returns specific reason for wp-prefixed probes', () => {
+		expect(getSuspiciousPathReason('/wp-login.php')).toBe('wordpress-probe');
+	});
+
+	it('returns generic php reason for other script probes', () => {
+		expect(getSuspiciousPathReason('/anything.php')).toBe('php-script-probe');
+	});
+
+	it('returns null for non-suspicious paths', () => {
+		expect(getSuspiciousPathReason('/blog/my-post')).toBeNull();
+	});
+});
+
+describe('isSuspiciousPath', () => {
+	it.each(['/xmlrpc.php', '/wp-login.php', '/wp-admin/admin-ajax.php', '/anything.php'])(
+		'detects suspicious path %s',
+		(path) => {
+			expect(isSuspiciousPath(path)).toBe(true);
+		}
+	);
+
+	it('ignores non-suspicious paths', () => {
+		expect(isSuspiciousPath('/blog/my-post')).toBe(false);
+	});
+});
+
+describe('shouldSampleSuspiciousLog', () => {
+	it('returns a stable result for a given input', () => {
+		expect(shouldSampleSuspiciousLog('/xmlrpc.php', 'scanner-bot')).toBe(
+			shouldSampleSuspiciousLog('/xmlrpc.php', 'scanner-bot')
+		);
+	});
+});
+
+describe('handle', () => {
+	it('short-circuits suspicious requests with a 404', async () => {
+		const resolve = vi.fn().mockResolvedValue(new Response('ok'));
+		const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+
+		const response = await handle({
+			event: {
+				url: new URL('https://example.com/xmlrpc.php'),
+				request: new Request('https://example.com/xmlrpc.php', {
+					headers: {
+						'user-agent': 'scanner-bot'
+					}
+				})
+			},
+			resolve
+		} as unknown as Parameters<typeof handle>[0]);
+
+		expect(response.status).toBe(404);
+		expect(await response.text()).toBe('Not Found');
+		expect(resolve).not.toHaveBeenCalled();
+
+		warn.mockRestore();
+	});
+
+	it('passes non-suspicious requests to resolve', async () => {
+		const resolve = vi.fn().mockResolvedValue(new Response('ok'));
+
+		const response = await handle({
+			event: {
+				url: new URL('https://example.com/about'),
+				request: new Request('https://example.com/about')
+			},
+			resolve
+		} as unknown as Parameters<typeof handle>[0]);
+
+		expect(resolve).toHaveBeenCalledOnce();
+		expect(response).toBeInstanceOf(Response);
+		expect(await response.text()).toBe('ok');
+	});
+});

--- a/src/hooks.server.ts
+++ b/src/hooks.server.ts
@@ -1,0 +1,71 @@
+import type { Handle } from '@sveltejs/kit';
+
+const LOG_SAMPLE_PERCENT = 10;
+
+const SUSPICIOUS_PATH_RULES = [
+	{
+		reason: 'xmlrpc-endpoint',
+		test: (pathname: string) => pathname === '/xmlrpc.php'
+	},
+	{
+		reason: 'wordpress-probe',
+		test: (pathname: string) => pathname.startsWith('/wp-')
+	},
+	{
+		reason: 'php-script-probe',
+		test: (pathname: string) => pathname.endsWith('.php')
+	}
+] as const;
+
+export const getSuspiciousPathReason = (pathname: string): string | null => {
+	const matchedRule = SUSPICIOUS_PATH_RULES.find((rule) => rule.test(pathname));
+
+	return matchedRule?.reason ?? null;
+};
+
+export const isSuspiciousPath = (pathname: string): boolean =>
+	getSuspiciousPathReason(pathname) !== null;
+
+export const shouldSampleSuspiciousLog = (pathname: string, userAgent: string): boolean => {
+	let hash = 0;
+	const input = `${pathname}|${userAgent}`;
+
+	for (let index = 0; index < input.length; index += 1) {
+		hash = (hash * 31 + input.charCodeAt(index)) >>> 0;
+	}
+
+	return hash % 100 < LOG_SAMPLE_PERCENT;
+};
+
+const createBlockedResponse = (): Response =>
+	new Response('Not Found', {
+		status: 404,
+		headers: {
+			'cache-control': 'no-store',
+			'x-robots-tag': 'noindex'
+		}
+	});
+
+export const handle: Handle = async ({ event, resolve }) => {
+	const { pathname } = event.url;
+	const suspiciousPathReason = getSuspiciousPathReason(pathname);
+
+	if (suspiciousPathReason === null) {
+		return resolve(event);
+	}
+
+	const userAgent = event.request.headers.get('user-agent') ?? 'unknown';
+
+	if (shouldSampleSuspiciousLog(pathname, userAgent)) {
+		console.warn('Blocked suspicious request path', {
+			reason: suspiciousPathReason,
+			path: pathname,
+			method: event.request.method,
+			userAgent,
+			referer: event.request.headers.get('referer'),
+			ip: event.request.headers.get('cf-connecting-ip')
+		});
+	}
+
+	return createBlockedResponse();
+};


### PR DESCRIPTION
## Summary

Adds a SvelteKit server hook that short-circuits high-volume suspicious probe paths before route handling. The guard currently covers `/xmlrpc.php`, `/wp-*` probes, and generic `.php` script probes with a low-information `404 Not Found` response.

The implementation also adds deterministic sampled warning logs with request metadata and a reason label, plus unit coverage for reason precedence, suspicious path classification, deterministic sampling, hook short-circuiting, and pass-through behavior.

## Validation

- `npm run check` passed.
- `npm exec prettier -- --check README.md src/hooks.server.ts src/hooks.server.test.ts` passed.
- `npm run lint` did not pass because repo-wide `prettier --check .` reports existing formatting/line-ending issues across 36 files outside this PR.
- `npm run security` could not be completed because `osv-scanner` is not installed on PATH; installing it with Winget was declined for now.

## Notes

The PR is opened as a draft so CI can give the authoritative result before it is marked ready for review.