### PR TITLE
[codex] Add Open Graph metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ Component-scoped styles should live in colocated `*.module.css` files rather tha
 - **Service layer**: navigation/page clients are abstracted behind small interfaces in `src/lib/services/**`.
 - **Content source**: Contentful is the backing CMS for page content and nav links.
 - **Library route**: `src/routes/library/+page.svelte` renders a curated bookshelf-style library from local seed data in `src/lib/services/library/library.ts`.
+- **SEO metadata**: public routes use `src/lib/services/seo/open-graph.ts` and `OpenGraphHead.svelte` for canonical Open Graph tags. See `docs/seo.md` before adding new public pages or content types.
 - **Component library**: atoms/molecules/organisms live in `src/lib/**` with Storybook stories and docs.
 - **Cloudflare target**: adapter is `@sveltejs/adapter-cloudflare` and Worker config is in `wrangler.toml`.
 
@@ -207,6 +208,7 @@ Before handing a branch over for review or merge, run `npm run check`, `npm run 
 - `src/hooks.server.ts` blocks high-volume probe paths (`*.php`, `/wp-*`, and `/xmlrpc.php`) early in the request lifecycle with a low-information `404 Not Found` response, and emits sampled warning logs with request metadata for observability.
 - `src/routes/robots.txt/+server.ts` serves crawler guidance dynamically: only the canonical production origin `https://www.chrisipowell.co.uk` allows crawling and advertises the sitemap, while preview, branch, staging, and local origins return `Disallow: /`.
 - `src/routes/sitemap.xml/+server.ts` serves a canonical XML sitemap built from first-class public routes plus published Contentful pages and blog posts, with 24-hour edge-friendly caching. When a new public route or indexable content type launches, update `src/lib/services/seo/sitemap.ts` in the same change so it stays discoverable.
+- Open Graph metadata uses the same canonical production origin, strips query strings/trailing slashes, includes the `Chris I Powell` site name in titles, and defaults to `static/logo-cip.png` when a page-specific image is unavailable.
 
 ## GitHub automation
 

--- a/contentful/migrations/20260426000000-add-blog-post-description.cjs
+++ b/contentful/migrations/20260426000000-add-blog-post-description.cjs
@@ -1,0 +1,21 @@
+module.exports = function migration(migration) {
+	const blogPost = migration.editContentType('blogPost');
+
+	blogPost
+		.createField('description')
+		.name('Description')
+		.type('Text')
+		.required(false)
+		.validations([
+			{
+				size: {
+					max: 300
+				}
+			}
+		]);
+
+	blogPost.changeFieldControl('description', 'builtin', 'multipleLine', {
+		helpText:
+			'Short summary used for page descriptions and Open Graph previews. If blank, the site derives a fallback from the post body.'
+	});
+};

--- a/contentful/migrations/README.md
+++ b/contentful/migrations/README.md
@@ -44,6 +44,7 @@ It updates the existing fields to match the current expected shape:
 
 - `title` (`Symbol`, required, unique)
 - `slug` (`Symbol`, required, unique)
+- `description` (`Text`, optional, max 300 characters; used for page descriptions and Open Graph previews)
 - `body` (`RichText`, optional)
 - `video` (`Object`, optional)
 - `tags` (`Array` of `Symbol`, optional, max 5)

--- a/docs/seo.md
+++ b/docs/seo.md
@@ -1,0 +1,38 @@
+# SEO metadata
+
+Public pages should emit canonical Open Graph metadata through the shared helpers in `src/lib/services/seo/`.
+
+## Canonical URLs
+
+- Use `buildOpenGraphMetadata` for page metadata and `buildCanonicalUrl` for standalone URL generation.
+- Canonical URLs are rooted at `https://www.chrisipowell.co.uk`.
+- Query strings, hashes, and trailing slashes are stripped from canonical metadata. Preview variants should never create separate canonical URLs.
+
+## Open Graph pattern
+
+Use `OpenGraphHead.svelte` with a metadata object from `buildOpenGraphMetadata`:
+
+<!-- markdownlint-disable MD010 -->
+
+```svelte
+<script lang="ts">
+	import OpenGraphHead from '$lib/services/seo/OpenGraphHead.svelte';
+	import { buildOpenGraphMetadata } from '$lib/services/seo/open-graph';
+
+	const metadata = buildOpenGraphMetadata({
+		title: 'Thoughts',
+		description: 'Short updates, ideas, and longer reflections from Chris I Powell.',
+		path: '/thoughts'
+	});
+</script>
+
+<OpenGraphHead {metadata} />
+```
+
+<!-- markdownlint-enable MD010 -->
+
+Blog posts should pass `type: 'article'` and prefer Contentful post imagery. Other public routes use the default `website` type and fall back to the site logo.
+
+## Contentful blog descriptions
+
+The `blogPost` content type includes an optional `description` field for link previews. If the field is blank, the app derives a fallback from the first 100 characters of the rich text body and uses the first embedded asset as the post social image when available.

--- a/src/lib/organisms/library_experience/LibraryExperience.svelte
+++ b/src/lib/organisms/library_experience/LibraryExperience.svelte
@@ -2,6 +2,8 @@
 	import Container from '$lib/atoms/container/Container.svelte';
 	import LibraryShelf from '$lib/organisms/library_shelf/LibraryShelf.svelte';
 	import type { LibraryEntryType, LibraryShelfEntry } from '$lib/services/library/library';
+	import OpenGraphHead from '$lib/services/seo/OpenGraphHead.svelte';
+	import { buildOpenGraphMetadata } from '$lib/services/seo/open-graph';
 	import styles from './LibraryExperience.module.css';
 
 	interface Props {
@@ -16,6 +18,13 @@
 	let { entries, topics, counts }: Props = $props();
 	let activeTopic = $state('all');
 	let activeTypes = $state<LibraryEntryType[]>(['book', 'article']);
+	const description =
+		'A curated shelf of books and articles shaping how Chris I Powell leads teams, designs systems, and ships meaningful work.';
+	const metadata = buildOpenGraphMetadata({
+		title: 'Library',
+		description,
+		path: '/library'
+	});
 
 	function formatTopic(topic: string) {
 		return topic.replace(/\b\w/g, (character) => character.toUpperCase());
@@ -75,13 +84,7 @@
 	);
 </script>
 
-<svelte:head>
-	<title>Chris I Powell - Library</title>
-	<meta
-		name="description"
-		content="A curated shelf of books and articles shaping how Chris I Powell leads teams, designs systems, and ships meaningful work."
-	/>
-</svelte:head>
+<OpenGraphHead {metadata} />
 
 <main class={styles.libraryPage}>
 	<Container>

--- a/src/lib/services/blog/Blog.ts
+++ b/src/lib/services/blog/Blog.ts
@@ -19,6 +19,12 @@ export interface BlogPostPreview {
 export interface BlogPost {
 	title: string;
 	slug: string;
+	description: string;
+	socialImage: {
+		url: string;
+		title: string;
+		description: string;
+	} | null;
 	body: { nodeType: string; content: unknown[] } | null;
 	tags: string[];
 	contentfulMetadata: {

--- a/src/lib/services/cms/content_types.d.ts
+++ b/src/lib/services/cms/content_types.d.ts
@@ -15,6 +15,7 @@ export type ContentfulBlogPost = {
 	fields: {
 		slug: EntryFieldTypes.Symbol;
 		title: EntryFieldTypes.Symbol;
+		description: EntryFieldTypes.Text;
 		body: EntryFieldTypes.RichText;
 		tags: EntryFieldTypes.Array<EntryFieldTypes.Symbol>;
 	};

--- a/src/lib/services/cms/contentful.test.ts
+++ b/src/lib/services/cms/contentful.test.ts
@@ -200,6 +200,8 @@ describe('Contentful blog queries', () => {
 		await expect(cms.getBlogPost('a-thoughtful-post')).resolves.toEqual({
 			title: 'A thoughtful post',
 			slug: 'a-thoughtful-post',
+			description: '',
+			socialImage: null,
 			body: { nodeType: 'document', content: [] },
 			tags: ['leadership', 'culture'],
 			contentfulMetadata: {
@@ -217,6 +219,66 @@ describe('Contentful blog queries', () => {
 			'fields.slug': 'a-thoughtful-post',
 			include: 10,
 			limit: 1
+		});
+	});
+
+	test('derives blog post metadata from description, body, and embedded images', async () => {
+		getEntriesMock.mockResolvedValueOnce({
+			items: [
+				{
+					sys: { id: 'post-2', locale: 'en-US' },
+					fields: {
+						title: 'A visual post',
+						slug: 'a-visual-post',
+						description: '',
+						body: {
+							nodeType: 'document',
+							content: [
+								{
+									nodeType: 'paragraph',
+									content: [
+										{
+											nodeType: 'text',
+											value:
+												'This first paragraph is long enough to become a concise fallback description for the shared link preview.'
+										}
+									]
+								},
+								{
+									nodeType: 'embedded-asset-block',
+									data: {
+										target: {
+											fields: {
+												title: 'Workshop wall',
+												description: 'Sticky notes arranged on a workshop wall',
+												file: {
+													url: '//images.ctfassets.net/blog/workshop-wall.jpg'
+												}
+											}
+										}
+									}
+								}
+							]
+						},
+						tags: []
+					}
+				}
+			]
+		});
+
+		const { default: Contentful } = await import('./contentful');
+		const cms = new Contentful();
+
+		await expect(cms.getBlogPost('a-visual-post')).resolves.toMatchObject({
+			title: 'A visual post',
+			slug: 'a-visual-post',
+			description:
+				'This first paragraph is long enough to become a concise fallback description for the shared link pre...',
+			socialImage: {
+				url: 'https://images.ctfassets.net/blog/workshop-wall.jpg',
+				title: 'Workshop wall',
+				description: 'Sticky notes arranged on a workshop wall'
+			}
 		});
 	});
 

--- a/src/lib/services/cms/contentful.ts
+++ b/src/lib/services/cms/contentful.ts
@@ -25,6 +25,7 @@ export interface SitemapContentEntry {
 
 type RichTextNode = {
 	nodeType?: string;
+	value?: string;
 	data?: {
 		target?: {
 			sys?: {
@@ -36,6 +37,7 @@ type RichTextNode = {
 			};
 			fields?: {
 				title?: string;
+				subtitle?: string;
 				subjectTag?: string;
 				items?: Array<{ fields?: Record<string, string> }>;
 			};
@@ -156,6 +158,10 @@ class Contentful implements NavClient, PageClient {
 				return {
 					title: page.fields.title as string,
 					slug: page.fields.slug as string,
+					description: this.truncateDescription(
+						this.getRichTextPlainText(page.fields.content as RichTextNode | null | undefined),
+						160
+					),
 					content: page.fields.content ?? null,
 					breadcrumbs,
 					contentfulMetadata: {
@@ -331,6 +337,64 @@ class Contentful implements NavClient, PageClient {
 		};
 	}
 
+	private getRichTextPlainText(content: RichTextNode | null | undefined): string {
+		if (!content) {
+			return '';
+		}
+
+		const parts: string[] = [];
+
+		const walk = (node: RichTextNode) => {
+			if (node.nodeType === 'text' && node.value) {
+				parts.push(node.value);
+			}
+
+			const target = node.data?.target;
+			if (node.nodeType === 'embedded-entry-block' && target?.fields?.subtitle) {
+				parts.push(target.fields.subtitle);
+			}
+
+			for (const child of node.content ?? []) {
+				walk(child);
+			}
+		};
+
+		walk(content);
+		return parts.join(' ').replace(/\s+/g, ' ').trim();
+	}
+
+	private truncateDescription(value: string, maxLength: number): string {
+		const normalized = value.replace(/\s+/g, ' ').trim();
+
+		if (normalized.length <= maxLength) {
+			return normalized;
+		}
+
+		return `${normalized.slice(0, maxLength).trimEnd()}...`;
+	}
+
+	private getFirstRichTextAssetImage(
+		content: RichTextNode | null | undefined
+	): LibraryImage | null {
+		if (!content) {
+			return null;
+		}
+
+		if (content.nodeType === 'embedded-asset-block') {
+			return this.getAssetImage(content.data?.target);
+		}
+
+		for (const child of content.content ?? []) {
+			const image = this.getFirstRichTextAssetImage(child);
+
+			if (image) {
+				return image;
+			}
+		}
+
+		return null;
+	}
+
 	private mapLibraryEntryPreview(
 		entry: contentful.Entry<ContentfulLibraryEntry>
 	): LibraryEntryPreview {
@@ -497,12 +561,18 @@ class Contentful implements NavClient, PageClient {
 		}
 
 		const post = entries.items[0];
+		const body = (post.fields.body as RichTextDocument | null | undefined) ?? null;
+		const explicitDescription = this.getSymbolFieldValue(post.fields.description);
+		const derivedDescription = this.getRichTextPlainText(body as RichTextNode | null | undefined);
 
 		return {
 			title: this.getSymbolFieldValue(post.fields.title),
 			slug: this.getSymbolFieldValue(post.fields.slug),
-			body:
-				(post.fields.body as { nodeType: string; content: unknown[] } | null | undefined) ?? null,
+			description: explicitDescription
+				? this.truncateDescription(explicitDescription, 160)
+				: this.truncateDescription(derivedDescription, 100),
+			socialImage: this.getFirstRichTextAssetImage(body as RichTextNode | null | undefined),
+			body,
 			tags: this.getTagFieldValues(post.fields.tags),
 			contentfulMetadata: {
 				entryId: post.sys.id,

--- a/src/lib/services/page/Page.ts
+++ b/src/lib/services/page/Page.ts
@@ -3,6 +3,7 @@ import type { NavLink } from '../navigation/nav';
 export interface Page {
 	title: string;
 	slug: string;
+	description: string;
 	content: { nodeType: string; content: unknown[] } | null;
 	breadcrumbs: NavLink[];
 	contentfulMetadata: {

--- a/src/lib/services/seo/OpenGraphHead.svelte
+++ b/src/lib/services/seo/OpenGraphHead.svelte
@@ -1,0 +1,21 @@
+<script lang="ts">
+	import type { OpenGraphMetadata } from './open-graph';
+
+	interface Props {
+		metadata: OpenGraphMetadata;
+	}
+
+	let { metadata }: Props = $props();
+</script>
+
+<svelte:head>
+	<title>{metadata.title}</title>
+	<meta name="description" content={metadata.description} />
+	<meta property="og:title" content={metadata.title} />
+	<meta property="og:description" content={metadata.description} />
+	<meta property="og:type" content={metadata.type} />
+	<meta property="og:url" content={metadata.url} />
+	<meta property="og:site_name" content={metadata.siteName} />
+	<meta property="og:image" content={metadata.image.url} />
+	<meta property="og:image:alt" content={metadata.image.alt} />
+</svelte:head>

--- a/src/lib/services/seo/canonical.ts
+++ b/src/lib/services/seo/canonical.ts
@@ -1,0 +1,37 @@
+import { PRODUCTION_ORIGIN } from './robots';
+
+export function normalizeCanonicalPath(value: string): string | null {
+	const trimmed = value.trim();
+
+	if (!trimmed) {
+		return null;
+	}
+
+	const withoutQuery = trimmed.split(/[?#]/, 1)[0];
+	if (!withoutQuery) {
+		return null;
+	}
+
+	if (withoutQuery === '/' || withoutQuery.toLowerCase() === 'home') {
+		return '/';
+	}
+
+	const withoutLeadingSlash = withoutQuery.replace(/^\/+/, '');
+	const normalized = withoutLeadingSlash.replace(/\/+$/, '');
+
+	if (!normalized) {
+		return '/';
+	}
+
+	return `/${normalized}`;
+}
+
+export function buildCanonicalUrl(value: string): string {
+	const path = normalizeCanonicalPath(value) ?? '/';
+
+	if (path === '/') {
+		return PRODUCTION_ORIGIN;
+	}
+
+	return `${PRODUCTION_ORIGIN}${path}`;
+}

--- a/src/lib/services/seo/open-graph.test.ts
+++ b/src/lib/services/seo/open-graph.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, test } from 'vitest';
+
+import { PRODUCTION_ORIGIN } from './robots';
+import {
+	DEFAULT_SOCIAL_IMAGE_PATH,
+	SITE_NAME,
+	buildOpenGraphMetadata,
+	formatSeoTitle,
+	resolveSocialImageUrl
+} from './open-graph';
+
+describe('formatSeoTitle', () => {
+	test('appends the site name to page titles', () => {
+		expect(formatSeoTitle('Thoughts')).toBe('Thoughts | Chris I Powell');
+	});
+
+	test('uses the site name by itself when no page title is available', () => {
+		expect(formatSeoTitle('')).toBe(SITE_NAME);
+	});
+});
+
+describe('resolveSocialImageUrl', () => {
+	test('keeps external image URLs and expands root-relative/static asset paths', () => {
+		expect(resolveSocialImageUrl('//images.ctfassets.net/post/main.png')).toBe(
+			'https://images.ctfassets.net/post/main.png'
+		);
+		expect(resolveSocialImageUrl('/logo-cip.png')).toBe(`${PRODUCTION_ORIGIN}/logo-cip.png`);
+	});
+
+	test('rejects unsupported image URL protocols', () => {
+		expect(resolveSocialImageUrl('javascript:alert(1)')).toBeNull();
+	});
+});
+
+describe('buildOpenGraphMetadata', () => {
+	test('builds canonical Open Graph metadata without query strings or trailing slashes', () => {
+		expect(
+			buildOpenGraphMetadata({
+				title: 'About',
+				description: 'About Chris I Powell.',
+				path: '/about/?preview=true'
+			})
+		).toEqual({
+			title: 'About | Chris I Powell',
+			description: 'About Chris I Powell.',
+			type: 'website',
+			url: `${PRODUCTION_ORIGIN}/about`,
+			siteName: SITE_NAME,
+			image: {
+				url: `${PRODUCTION_ORIGIN}${DEFAULT_SOCIAL_IMAGE_PATH}`,
+				alt: SITE_NAME
+			}
+		});
+	});
+
+	test('uses article type and supplied image for blog posts', () => {
+		expect(
+			buildOpenGraphMetadata({
+				title: 'Leading teams',
+				description: 'A post about leadership.',
+				path: '/thoughts/leading-teams',
+				type: 'article',
+				imageUrl: 'https://images.ctfassets.net/post/social.png',
+				imageAlt: 'People around a workshop table'
+			})
+		).toMatchObject({
+			title: 'Leading teams | Chris I Powell',
+			description: 'A post about leadership.',
+			type: 'article',
+			url: `${PRODUCTION_ORIGIN}/thoughts/leading-teams`,
+			image: {
+				url: 'https://images.ctfassets.net/post/social.png',
+				alt: 'People around a workshop table'
+			}
+		});
+	});
+});

--- a/src/lib/services/seo/open-graph.ts
+++ b/src/lib/services/seo/open-graph.ts
@@ -1,0 +1,92 @@
+import { buildCanonicalUrl } from './canonical';
+
+export const SITE_NAME = 'Chris I Powell';
+export const DEFAULT_SITE_DESCRIPTION =
+	'Product, design, and engineering leadership notes from Chris I Powell.';
+export const DEFAULT_SOCIAL_IMAGE_PATH = '/logo-cip.png';
+
+export type OpenGraphType = 'website' | 'article';
+
+export interface OpenGraphImage {
+	url: string;
+	alt?: string;
+}
+
+export interface OpenGraphMetadata {
+	title: string;
+	description: string;
+	type: OpenGraphType;
+	url: string;
+	siteName: string;
+	image: OpenGraphImage;
+}
+
+interface BuildOpenGraphMetadataOptions {
+	title?: string;
+	description?: string;
+	path: string;
+	type?: OpenGraphType;
+	imageUrl?: string | null;
+	imageAlt?: string | null;
+}
+
+function cleanText(value: string): string {
+	return value.replace(/\s+/g, ' ').trim();
+}
+
+export function formatSeoTitle(title?: string): string {
+	const cleanTitle = cleanText(title ?? '');
+
+	if (!cleanTitle || cleanTitle === SITE_NAME) {
+		return SITE_NAME;
+	}
+
+	return `${cleanTitle} | ${SITE_NAME}`;
+}
+
+export function resolveSocialImageUrl(value?: string | null): string | null {
+	const cleanValue = cleanText(value ?? '');
+
+	if (!cleanValue) {
+		return null;
+	}
+
+	if (cleanValue.startsWith('//')) {
+		return `https:${cleanValue}`;
+	}
+
+	if (cleanValue.startsWith('/')) {
+		return buildCanonicalUrl(cleanValue);
+	}
+
+	try {
+		const url = new URL(cleanValue);
+		return ['http:', 'https:'].includes(url.protocol) ? url.toString() : null;
+	} catch {
+		return null;
+	}
+}
+
+export function buildOpenGraphMetadata({
+	title,
+	description = DEFAULT_SITE_DESCRIPTION,
+	path,
+	type = 'website',
+	imageUrl,
+	imageAlt
+}: BuildOpenGraphMetadataOptions): OpenGraphMetadata {
+	const resolvedImageUrl =
+		resolveSocialImageUrl(imageUrl) ?? buildCanonicalUrl(DEFAULT_SOCIAL_IMAGE_PATH);
+
+	return {
+		title: formatSeoTitle(title),
+		description: cleanText(description) || DEFAULT_SITE_DESCRIPTION,
+		type,
+		url: buildCanonicalUrl(path),
+		siteName: SITE_NAME,
+		image: {
+			url: resolvedImageUrl,
+			alt: cleanText(imageAlt ?? '') || SITE_NAME
+		}
+	};
+}

--- a/src/lib/services/seo/open-graph.ts
+++ b/src/lib/services/seo/open-graph.ts
@@ -5,9 +5,9 @@ export const DEFAULT_SITE_DESCRIPTION =
 	'Product, design, and engineering leadership notes from Chris I Powell.';
 export const DEFAULT_SOCIAL_IMAGE_PATH = '/logo-cip.png';
 
-export type OpenGraphType = 'website' | 'article';
+type OpenGraphType = 'website' | 'article';
 
-export interface OpenGraphImage {
+interface OpenGraphImage {
 	url: string;
 	alt?: string;
 }

--- a/src/lib/services/seo/sitemap.test.ts
+++ b/src/lib/services/seo/sitemap.test.ts
@@ -1,7 +1,8 @@
 import { describe, expect, test } from 'vitest';
 
+import { normalizeCanonicalPath } from './canonical';
 import { PRODUCTION_ORIGIN } from './robots';
-import { buildSitemapUrls, buildSitemapXml, normalizeCanonicalPath } from './sitemap';
+import { buildSitemapUrls, buildSitemapXml } from './sitemap';
 
 describe('normalizeCanonicalPath', () => {
 	test('maps home slugs and trims extra delimiters', () => {

--- a/src/lib/services/seo/sitemap.ts
+++ b/src/lib/services/seo/sitemap.ts
@@ -1,7 +1,7 @@
 import { ContentfulCache } from '$lib/services/cms/cache';
 import Contentful, { type SitemapContentEntry } from '$lib/services/cms/contentful';
 
-import { PRODUCTION_ORIGIN } from './robots';
+import { buildCanonicalUrl, normalizeCanonicalPath } from './canonical';
 
 const SITEMAP_CACHE_TTL = 60 * 60 * 24;
 export const SITEMAP_CACHE_CONTROL = `public, max-age=0, s-maxage=${SITEMAP_CACHE_TTL}`;
@@ -57,32 +57,6 @@ function normalizeLastmod(value: string): string {
 	return lastModified.toISOString();
 }
 
-export function normalizeCanonicalPath(value: string): string | null {
-	const trimmed = value.trim();
-
-	if (!trimmed) {
-		return null;
-	}
-
-	const withoutQuery = trimmed.split(/[?#]/, 1)[0];
-	if (!withoutQuery) {
-		return null;
-	}
-
-	if (withoutQuery === '/' || withoutQuery.toLowerCase() === 'home') {
-		return '/';
-	}
-
-	const withoutLeadingSlash = withoutQuery.replace(/^\/+/, '');
-	const normalized = withoutLeadingSlash.replace(/\/+$/, '');
-
-	if (!normalized) {
-		return '/';
-	}
-
-	return `/${normalized}`;
-}
-
 function buildBlogPostPath(slug: string): string | null {
 	const trimmed = slug.trim();
 
@@ -102,14 +76,6 @@ function buildBlogPostPath(slug: string): string | null {
 	}
 
 	return `/thoughts/${normalized}`;
-}
-
-function buildCanonicalUrl(path: string): string {
-	if (path === '/') {
-		return PRODUCTION_ORIGIN;
-	}
-
-	return `${PRODUCTION_ORIGIN}${path}`;
 }
 
 function mapStaticRoute(route: (typeof STATIC_SITEMAP_ROUTES)[number]): SitemapUrlEntry {

--- a/src/routes/[...catchall]/+page.svelte
+++ b/src/routes/[...catchall]/+page.svelte
@@ -1,11 +1,20 @@
 <script lang="ts">
 	import { invalidateAll } from '$app/navigation';
 	import ContentfulRichText from '$lib/organisms/rich_text/ContentfulRichText.svelte';
+	import OpenGraphHead from '$lib/services/seo/OpenGraphHead.svelte';
+	import { DEFAULT_SITE_DESCRIPTION, buildOpenGraphMetadata } from '$lib/services/seo/open-graph';
 	import { ContentfulLivePreview } from '@contentful/live-preview';
 	import { onMount } from 'svelte';
 
 	let { data } = $props();
 	let pageContent = $derived(data.content);
+	const metadata = $derived(
+		buildOpenGraphMetadata({
+			title: data.title,
+			description: data.description || DEFAULT_SITE_DESCRIPTION,
+			path: data.slug
+		})
+	);
 
 	onMount(() => {
 		if (!data.livePreview.enabled) {
@@ -50,9 +59,7 @@
 	});
 </script>
 
-<svelte:head>
-	<title>Chris I Powell - {data.title}</title>
-</svelte:head>
+<OpenGraphHead {metadata} />
 
 <main
 	data-contentful-entry-id={data.contentfulMetadata.entryId}

--- a/src/routes/library/[slug]/+page.svelte
+++ b/src/routes/library/[slug]/+page.svelte
@@ -2,6 +2,8 @@
 	import { invalidateAll } from '$app/navigation';
 	import Container from '$lib/atoms/container/Container.svelte';
 	import ContentfulRichText from '$lib/organisms/rich_text/ContentfulRichText.svelte';
+	import OpenGraphHead from '$lib/services/seo/OpenGraphHead.svelte';
+	import { buildOpenGraphMetadata } from '$lib/services/seo/open-graph';
 	import { ContentfulLivePreview } from '@contentful/live-preview';
 	import { onMount } from 'svelte';
 
@@ -40,6 +42,15 @@
 
 	let { data }: Props = $props();
 	const notes = $derived(data.notes);
+	const metadata = $derived(
+		buildOpenGraphMetadata({
+			title: data.title,
+			description: data.summary,
+			path: `/library/${data.slug}`,
+			imageUrl: data.coverImage?.url,
+			imageAlt: data.coverImage?.description || data.coverImage?.title || data.title
+		})
+	);
 
 	function formatDate(value: string): string {
 		if (!value) {
@@ -107,9 +118,7 @@
 	});
 </script>
 
-<svelte:head>
-	<title>Chris I Powell - {data.title}</title>
-</svelte:head>
+<OpenGraphHead {metadata} />
 
 <main class="library-entry-page">
 	<Container maxWidth="narrow">

--- a/src/routes/thoughts/+page.svelte
+++ b/src/routes/thoughts/+page.svelte
@@ -1,6 +1,8 @@
 <script lang="ts">
 	import ThreeColumnSection from '$lib/organisms/three_column_section/ThreeColumnSection.svelte';
 	import type { BlogPostPreview } from '$lib/services/blog/Blog';
+	import OpenGraphHead from '$lib/services/seo/OpenGraphHead.svelte';
+	import { buildOpenGraphMetadata } from '$lib/services/seo/open-graph';
 
 	interface Props {
 		data: {
@@ -22,15 +24,15 @@
 
 	const thoughtItems = $derived(mapPostItems(data.recentPosts));
 	const leadershipItems = $derived(mapPostItems(data.leadershipPosts));
+	const description = 'Short updates, ideas, and longer reflections from Chris I Powell.';
+	const metadata = buildOpenGraphMetadata({
+		title: 'Thoughts',
+		description,
+		path: '/thoughts'
+	});
 </script>
 
-<svelte:head>
-	<title>Chris I Powell - Thoughts</title>
-	<meta
-		name="description"
-		content="Short updates, ideas, and longer reflections from Chris I Powell."
-	/>
-</svelte:head>
+<OpenGraphHead {metadata} />
 
 <main class="thoughts-page">
 	<div class="thoughts-page__intro">

--- a/src/routes/thoughts/[slug]/+page.svelte
+++ b/src/routes/thoughts/[slug]/+page.svelte
@@ -2,6 +2,8 @@
 	import { invalidateAll } from '$app/navigation';
 	import Container from '$lib/atoms/container/Container.svelte';
 	import ContentfulRichText from '$lib/organisms/rich_text/ContentfulRichText.svelte';
+	import OpenGraphHead from '$lib/services/seo/OpenGraphHead.svelte';
+	import { buildOpenGraphMetadata } from '$lib/services/seo/open-graph';
 	import { ContentfulLivePreview } from '@contentful/live-preview';
 	import { onMount } from 'svelte';
 
@@ -9,6 +11,12 @@
 		data: {
 			title: string;
 			slug: string;
+			description: string;
+			socialImage: {
+				url: string;
+				title: string;
+				description: string;
+			} | null;
 			body: { nodeType: string; content: unknown[] } | null;
 			tags: string[];
 			contentfulMetadata: {
@@ -23,6 +31,16 @@
 
 	let { data }: Props = $props();
 	const postBody = $derived(data.body);
+	const metadata = $derived(
+		buildOpenGraphMetadata({
+			title: data.title,
+			description: data.description,
+			path: `/thoughts/${data.slug}`,
+			type: 'article',
+			imageUrl: data.socialImage?.url,
+			imageAlt: data.socialImage?.description || data.socialImage?.title || data.title
+		})
+	);
 
 	onMount(() => {
 		if (!data.livePreview.enabled) {
@@ -67,9 +85,7 @@
 	});
 </script>
 
-<svelte:head>
-	<title>Chris I Powell - {data.title}</title>
-</svelte:head>
+<OpenGraphHead {metadata} />
 
 <main class="thought-post">
 	<Container maxWidth="narrow">


### PR DESCRIPTION
## Summary

- add centralized canonical URL and Open Graph metadata helpers for public pages
- render shared Open Graph head tags across Contentful pages, thoughts, blog posts, and library pages
- add a Contentful `blogPost.description` migration and app-side fallback metadata from rich text/body imagery
- document the SEO metadata pattern for future public routes and content types

## Validation

- `npm run check`
- `npm run lint:code`
- `npm run lint:docs`
- touched-file Prettier check
- `npm run test:unit -- --project=unit`
- focused unit coverage for Open Graph, sitemap canonical paths, and Contentful blog metadata mapping

## Local blockers

- Full `npm run lint` still stops at repo-wide Prettier drift outside this change.
- `npm run security` is blocked locally because `osv-scanner`, `gitleaks`, and `semgrep` are not installed on PATH.
- Unscoped `npm run test:unit` also runs Storybook browser tests; in this temp worktree that path is blocked by the dependency junction/Vite allow-list setup, so the unit project was run directly.