### PR TITLE
Add JSON-LD structured data for site and blog posts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,7 +89,7 @@ jobs:
 
       - name: Install OSV-Scanner and Gitleaks
         run: |
-          go install github.com/google/osv-scanner/v2/cmd/osv-scanner@latest
+          go install github.com/google/osv-scanner/v2/cmd/osv-scanner@v2.3.5
           go install github.com/zricethezav/gitleaks/v8@latest
           echo "$HOME/go/bin" >> "$GITHUB_PATH"
 

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -33,7 +33,7 @@ jobs:
 
       - name: Install OSV-Scanner and Gitleaks
         run: |
-          go install github.com/google/osv-scanner/v2/cmd/osv-scanner@latest
+          go install github.com/google/osv-scanner/v2/cmd/osv-scanner@v2.3.5
           go install github.com/zricethezav/gitleaks/v8@latest
           echo "$HOME/go/bin" >> "$GITHUB_PATH"
 

--- a/README.md
+++ b/README.md
@@ -33,6 +33,13 @@ Component-scoped styles should live in colocated `*.module.css` files rather tha
 - **Component library**: atoms/molecules/organisms live in `src/lib/**` with Storybook stories and docs.
 - **Cloudflare target**: adapter is `@sveltejs/adapter-cloudflare` and Worker config is in `wrangler.toml`.
 
+### SEO and structured data
+
+- `src/lib/services/seo/structured-data.ts` builds JSON-LD for the personal brand, site, and blog posts.
+- The app shell emits `WebSite` and `Person` schema on public pages.
+- Blog posts at `/thoughts/[slug]` emit `Article` schema using Contentful title, description/body fallback, tags, and publish/update timestamps.
+- When a new indexable route or content type launches, update structured data and the sitemap together. See `docs/structured-data.md`.
+
 ## Prerequisites
 
 - Node.js 24.14.1

--- a/README.md
+++ b/README.md
@@ -49,11 +49,11 @@ Component-scoped styles should live in colocated `*.module.css` files rather tha
 
 Optional local security tooling for `npm run security:*`:
 
-- `osv-scanner`
+- `osv-scanner` `v2.3.5`
 - `gitleaks`
 - `semgrep`
 
-CI installs those tools automatically. For local use, install them with your preferred package manager before running the security scripts.
+CI installs those tools automatically. OSV-Scanner is pinned to `v2.3.5` in CI because newer source installs can break on upstream module metadata. For local use, install the same version or use your preferred package manager before running the security scripts.
 
 ## Setup
 

--- a/contentful/migrations/20260502000000-add-blog-post-description.cjs
+++ b/contentful/migrations/20260502000000-add-blog-post-description.cjs
@@ -1,0 +1,13 @@
+module.exports = function migration(migration) {
+	const blogPost = migration.editContentType('blogPost');
+
+	blogPost
+		.createField('description')
+		.name('Description')
+		.type('Text')
+		.required(false)
+		.validations([{ size: { min: 1, max: 300 } }]);
+
+	blogPost.changeFieldControl('description', 'builtin', 'multipleLine');
+	blogPost.moveField('description').afterField('title');
+};

--- a/docs/structured-data.md
+++ b/docs/structured-data.md
@@ -1,0 +1,21 @@
+# Structured Data
+
+The site emits JSON-LD from `src/lib/services/seo/structured-data.ts`.
+
+## Current schemas
+
+- `WebSite` identifies `https://www.chrisipowell.co.uk` as the canonical site.
+- `Person` identifies Chris I Powell as the personal brand owner, author, and publisher.
+- `Article` is emitted for `/thoughts/[slug]` blog posts.
+
+Blog post article data uses the same Contentful-backed values as page metadata:
+
+- `title` for headline/title text
+- `description` when present, or the first 100 characters of body text as a fallback
+- Contentful `sys.createdAt` as `datePublished`
+- Contentful `sys.updatedAt` as `dateModified`
+- `tags` as article keywords
+
+## Adding indexable content
+
+When a new public content type or first-class route becomes indexable, update the structured data builders alongside route metadata and the sitemap. Prefer adding a small schema builder in `structured-data.ts` and testing the generated JSON-LD rather than composing raw JSON in a Svelte component.

--- a/scripts/quality/security-deps.mjs
+++ b/scripts/quality/security-deps.mjs
@@ -7,6 +7,6 @@ await runCommand(
 		'Install OSV-Scanner before running this check.',
 		'Windows: winget install Google.OSV-Scanner or choco install osv-scanner',
 		'macOS: brew install osv-scanner',
-		'Cross-platform via Go: go install github.com/google/osv-scanner/v2/cmd/osv-scanner@latest'
+		'Cross-platform via Go: go install github.com/google/osv-scanner/v2/cmd/osv-scanner@v2.3.5'
 	].join('\n')
 );

--- a/src/lib/services/blog/Blog.ts
+++ b/src/lib/services/blog/Blog.ts
@@ -27,6 +27,8 @@ export interface BlogPost {
 	} | null;
 	body: { nodeType: string; content: unknown[] } | null;
 	tags: string[];
+	published: string;
+	lastUpdated: string;
 	contentfulMetadata: {
 		entryId: string;
 		locale: string;

--- a/src/lib/services/cms/contentful.test.ts
+++ b/src/lib/services/cms/contentful.test.ts
@@ -183,10 +183,16 @@ describe('Contentful blog queries', () => {
 		getEntriesMock.mockResolvedValueOnce({
 			items: [
 				{
-					sys: { id: 'post-1', locale: 'en-US' },
+					sys: {
+						id: 'post-1',
+						locale: 'en-US',
+						createdAt: '2026-04-01T08:30:00.000Z',
+						updatedAt: '2026-04-02T09:45:00.000Z'
+					},
 					fields: {
 						title: 'A thoughtful post',
 						slug: 'a-thoughtful-post',
+						description: 'A carefully written post summary.',
 						body: { nodeType: 'document', content: [] },
 						tags: ['leadership', 'culture']
 					}
@@ -200,10 +206,12 @@ describe('Contentful blog queries', () => {
 		await expect(cms.getBlogPost('a-thoughtful-post')).resolves.toEqual({
 			title: 'A thoughtful post',
 			slug: 'a-thoughtful-post',
-			description: '',
+			description: 'A carefully written post summary.',
 			socialImage: null,
 			body: { nodeType: 'document', content: [] },
 			tags: ['leadership', 'culture'],
+			published: '2026-04-01T08:30:00.000Z',
+			lastUpdated: '2026-04-02T09:45:00.000Z',
 			contentfulMetadata: {
 				entryId: 'post-1',
 				locale: 'en-US',
@@ -226,7 +234,12 @@ describe('Contentful blog queries', () => {
 		getEntriesMock.mockResolvedValueOnce({
 			items: [
 				{
-					sys: { id: 'post-2', locale: 'en-US' },
+					sys: {
+						id: 'post-2',
+						locale: 'en-US',
+						createdAt: '2026-04-03T10:15:00.000Z',
+						updatedAt: '2026-04-04T11:00:00.000Z'
+					},
 					fields: {
 						title: 'A visual post',
 						slug: 'a-visual-post',
@@ -278,7 +291,9 @@ describe('Contentful blog queries', () => {
 				url: 'https://images.ctfassets.net/blog/workshop-wall.jpg',
 				title: 'Workshop wall',
 				description: 'Sticky notes arranged on a workshop wall'
-			}
+			},
+			published: '2026-04-03T10:15:00.000Z',
+			lastUpdated: '2026-04-04T11:00:00.000Z'
 		});
 	});
 

--- a/src/lib/services/cms/contentful.ts
+++ b/src/lib/services/cms/contentful.ts
@@ -574,6 +574,8 @@ class Contentful implements NavClient, PageClient {
 			socialImage: this.getFirstRichTextAssetImage(body as RichTextNode | null | undefined),
 			body,
 			tags: this.getTagFieldValues(post.fields.tags),
+			published: post.sys.createdAt ?? post.sys.updatedAt ?? new Date(0).toISOString(),
+			lastUpdated: post.sys.updatedAt ?? post.sys.createdAt ?? new Date(0).toISOString(),
 			contentfulMetadata: {
 				entryId: post.sys.id,
 				locale: post.sys.locale || 'en-US',

--- a/src/lib/services/footer/footer-content.ts
+++ b/src/lib/services/footer/footer-content.ts
@@ -39,8 +39,8 @@ export const DEFAULT_SITE_FOOTER: SiteFooterContent = {
 	connect: {
 		title: 'Connect',
 		links: [
-			{ label: 'LinkedIn', href: 'https://linkedin.com' },
-			{ label: 'GitHub', href: 'https://github.com' },
+			{ label: 'LinkedIn', href: 'https://www.linkedin.com/in/chris-i-powell/' },
+			{ label: 'GitHub', href: 'https://github.com/CIPowell' },
 			{ label: 'Email', href: 'mailto:hello@cipowell.com' }
 		]
 	},

--- a/src/lib/services/seo/JsonLd.svelte
+++ b/src/lib/services/seo/JsonLd.svelte
@@ -1,0 +1,13 @@
+<script lang="ts">
+	interface Props {
+		json: string;
+	}
+
+	let { json }: Props = $props();
+	const scriptTag = $derived(`<script type="application/ld+json">${json}</${'script'}>`);
+</script>
+
+<svelte:head>
+	<!-- eslint-disable-next-line svelte/no-at-html-tags -->
+	{@html scriptTag}
+</svelte:head>

--- a/src/lib/services/seo/structured-data.test.ts
+++ b/src/lib/services/seo/structured-data.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, test } from 'vitest';
+
+import type { BlogPost } from '$lib/services/blog/Blog';
+
+import {
+	buildArticleStructuredData,
+	buildSameAsUrls,
+	buildSiteStructuredData,
+	serializeJsonLd
+} from './structured-data';
+import { PRODUCTION_ORIGIN } from './robots';
+
+describe('buildSameAsUrls', () => {
+	test('includes default personal profiles and configured social links', () => {
+		const sameAs = buildSameAsUrls([
+			{ label: 'Generic GitHub', href: 'https://github.com' },
+			{ label: 'Mastodon', href: 'https://mastodon.social/@chrisipowell' },
+			{ label: 'Email', href: 'mailto:hello@example.com' }
+		]);
+
+		expect(sameAs).toEqual([
+			'https://www.linkedin.com/in/chris-i-powell/',
+			'https://github.com/CIPowell',
+			'https://mastodon.social/@chrisipowell'
+		]);
+	});
+});
+
+describe('buildSiteStructuredData', () => {
+	test('builds a Person-centric site graph', () => {
+		const graph = buildSiteStructuredData(['https://github.com/CIPowell']);
+
+		expect(graph).toEqual({
+			'@context': 'https://schema.org',
+			'@graph': [
+				expect.objectContaining({
+					'@type': 'Person',
+					'@id': `${PRODUCTION_ORIGIN}/#person`,
+					name: 'Chris I Powell',
+					sameAs: ['https://github.com/CIPowell']
+				}),
+				expect.objectContaining({
+					'@type': 'WebSite',
+					'@id': `${PRODUCTION_ORIGIN}/#website`,
+					url: PRODUCTION_ORIGIN,
+					author: { '@id': `${PRODUCTION_ORIGIN}/#person` }
+				})
+			]
+		});
+	});
+});
+
+describe('buildArticleStructuredData', () => {
+	test('builds canonical Article data for a blog post', () => {
+		const post = {
+			title: 'Leading teams well',
+			slug: 'leading-teams-well',
+			description: 'A practical reflection on leading teams well.',
+			socialImage: null,
+			body: null,
+			tags: ['leadership', 'teams'],
+			published: '2026-04-01T08:30:00.000Z',
+			lastUpdated: '2026-04-02T09:45:00.000Z',
+			contentfulMetadata: {
+				entryId: 'post-1',
+				locale: 'en-US',
+				environment: 'master'
+			},
+			livePreview: {
+				enabled: false
+			}
+		} satisfies BlogPost;
+
+		expect(buildArticleStructuredData(post)).toEqual(
+			expect.objectContaining({
+				'@context': 'https://schema.org',
+				'@type': 'Article',
+				'@id': `${PRODUCTION_ORIGIN}/thoughts/leading-teams-well#article`,
+				url: `${PRODUCTION_ORIGIN}/thoughts/leading-teams-well`,
+				headline: 'Leading teams well',
+				name: 'Chris I Powell - Leading teams well',
+				description: 'A practical reflection on leading teams well.',
+				datePublished: '2026-04-01T08:30:00.000Z',
+				dateModified: '2026-04-02T09:45:00.000Z',
+				keywords: 'leadership, teams',
+				author: { '@id': `${PRODUCTION_ORIGIN}/#person` }
+			})
+		);
+	});
+});
+
+describe('serializeJsonLd', () => {
+	test('serializes JSON-LD safely for script content', () => {
+		const json = serializeJsonLd({
+			'@context': 'https://schema.org',
+			'@type': 'Thing',
+			name: '</script><script>alert(1)</script>'
+		});
+
+		expect(json).toContain('\\u003c/script\\u003e');
+		expect(json).not.toContain('</script><script>');
+	});
+});

--- a/src/lib/services/seo/structured-data.ts
+++ b/src/lib/services/seo/structured-data.ts
@@ -1,0 +1,147 @@
+import type { BlogPost } from '$lib/services/blog/Blog';
+import type { SiteFooterContent } from '$lib/services/footer/footer-content';
+
+import { PRODUCTION_ORIGIN } from './robots';
+
+const SITE_NAME = 'Chris I Powell';
+const SITE_DESCRIPTION = 'Building teams and systems that deliver real impact.';
+const LANGUAGE = 'en-GB';
+const PERSON_ID = `${PRODUCTION_ORIGIN}/#person`;
+const WEBSITE_ID = `${PRODUCTION_ORIGIN}/#website`;
+const DEFAULT_PERSON_SAME_AS = [
+	'https://www.linkedin.com/in/chris-i-powell/',
+	'https://github.com/CIPowell'
+];
+
+type JsonLdValue =
+	| string
+	| number
+	| boolean
+	| null
+	| JsonLdValue[]
+	| { [key: string]: JsonLdValue };
+
+type JsonLdNode = { [key: string]: JsonLdValue };
+type SameAsLink = SiteFooterContent['connect']['links'][number];
+
+function toCanonicalUrl(path: string): string {
+	if (path === '/') {
+		return PRODUCTION_ORIGIN;
+	}
+
+	const normalizedPath = path.startsWith('/') ? path : `/${path}`;
+	return `${PRODUCTION_ORIGIN}${normalizedPath}`;
+}
+
+function isSpecificSocialUrl(url: URL): boolean {
+	const hostname = url.hostname.replace(/^www\./, '');
+	const path = url.pathname.replace(/\/+$/, '');
+
+	if ((hostname === 'github.com' || hostname === 'linkedin.com') && !path) {
+		return false;
+	}
+
+	return url.protocol === 'https:' || url.protocol === 'http:';
+}
+
+function normalizeSameAsUrl(value: string): string | null {
+	try {
+		const url = new URL(value);
+
+		if (!isSpecificSocialUrl(url)) {
+			return null;
+		}
+
+		return url.toString();
+	} catch {
+		return null;
+	}
+}
+
+function normalizeIsoDate(value: string): string {
+	const date = new Date(value);
+
+	if (Number.isNaN(date.valueOf())) {
+		return new Date(0).toISOString();
+	}
+
+	return date.toISOString();
+}
+
+export function buildSameAsUrls(links: SameAsLink[]): string[] {
+	const sameAs = new Set<string>();
+
+	for (const value of DEFAULT_PERSON_SAME_AS) {
+		const normalized = normalizeSameAsUrl(value);
+		if (normalized) {
+			sameAs.add(normalized);
+		}
+	}
+
+	for (const link of links) {
+		const normalized = normalizeSameAsUrl(link.href);
+		if (normalized) {
+			sameAs.add(normalized);
+		}
+	}
+
+	return [...sameAs];
+}
+
+export function buildSiteStructuredData(sameAs: string[]): JsonLdNode {
+	return {
+		'@context': 'https://schema.org',
+		'@graph': [
+			{
+				'@type': 'Person',
+				'@id': PERSON_ID,
+				name: SITE_NAME,
+				url: PRODUCTION_ORIGIN,
+				description: SITE_DESCRIPTION,
+				sameAs
+			},
+			{
+				'@type': 'WebSite',
+				'@id': WEBSITE_ID,
+				url: PRODUCTION_ORIGIN,
+				name: SITE_NAME,
+				description: SITE_DESCRIPTION,
+				inLanguage: LANGUAGE,
+				author: { '@id': PERSON_ID },
+				publisher: { '@id': PERSON_ID }
+			}
+		]
+	};
+}
+
+export function buildArticleStructuredData(post: BlogPost): JsonLdNode {
+	const canonicalUrl = toCanonicalUrl(`/thoughts/${post.slug}`);
+	const keywords = post.tags.length ? post.tags.join(', ') : undefined;
+
+	return {
+		'@context': 'https://schema.org',
+		'@type': 'Article',
+		'@id': `${canonicalUrl}#article`,
+		url: canonicalUrl,
+		mainEntityOfPage: canonicalUrl,
+		isPartOf: { '@id': WEBSITE_ID },
+		headline: post.title,
+		name: `${SITE_NAME} - ${post.title}`,
+		description: post.description,
+		datePublished: normalizeIsoDate(post.published),
+		dateModified: normalizeIsoDate(post.lastUpdated),
+		inLanguage: LANGUAGE,
+		author: { '@id': PERSON_ID },
+		publisher: { '@id': PERSON_ID },
+		...(keywords ? { keywords } : {})
+	};
+}
+
+export function serializeJsonLd(data: JsonLdNode): string {
+	return JSON.stringify(data)
+		.replace(/</g, '\\u003c')
+		.replace(/>/g, '\\u003e')
+		.replace(/&/g, '\\u0026')
+		.replace(/\u2028/g, '\\u2028')
+		.replace(/\u2029/g, '\\u2029');
+}

--- a/src/routes/+layout.server.ts
+++ b/src/routes/+layout.server.ts
@@ -1,11 +1,17 @@
 import { NavigationService, getOrderedNavLinks, type NavLink } from '$lib/services/navigation/nav';
 import { DEFAULT_SITE_FOOTER, type SiteFooterContent } from '$lib/services/footer/footer-content';
 import { FooterService } from '$lib/services/footer/footer.server';
+import {
+	buildSameAsUrls,
+	buildSiteStructuredData,
+	serializeJsonLd
+} from '$lib/services/seo/structured-data';
 
 interface LayoutData {
 	navLinks: NavLink[];
 	footer: SiteFooterContent;
 	preview: boolean;
+	siteStructuredDataJson: string;
 }
 
 export async function load({ platform, url }) {
@@ -13,7 +19,8 @@ export async function load({ platform, url }) {
 	const layoutData: LayoutData = {
 		navLinks: [],
 		footer: DEFAULT_SITE_FOOTER,
-		preview
+		preview,
+		siteStructuredDataJson: ''
 	};
 
 	try {
@@ -31,6 +38,10 @@ export async function load({ platform, url }) {
 	}
 
 	console.log(`Loaded ${url} preview mode is ${preview}`);
+
+	layoutData.siteStructuredDataJson = serializeJsonLd(
+		buildSiteStructuredData(buildSameAsUrls(layoutData.footer.connect.links))
+	);
 
 	return layoutData;
 }

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -3,12 +3,15 @@
 	import Nav from '$lib/molecules/nav/Nav.svelte';
 	import SiteFooter from '$lib/organisms/site_footer/SiteFooter.svelte';
 	import LivePreviewBootstrap from '$lib/services/cms/LivePreviewBootstrap.svelte';
+	import JsonLd from '$lib/services/seo/JsonLd.svelte';
 
 	import '$lib/main.css';
 
 	let { data, children } = $props();
 	const footer = $derived(data.footer);
 </script>
+
+<JsonLd json={data.siteStructuredDataJson} />
 
 {#if data.preview}
 	<LivePreviewBootstrap locale="en-US" />

--- a/src/routes/thoughts/[slug]/+page.server.ts
+++ b/src/routes/thoughts/[slug]/+page.server.ts
@@ -1,5 +1,6 @@
 import type { BlogPost } from '$lib/services/blog/Blog';
 import Contentful from '$lib/services/cms/contentful';
+import { buildArticleStructuredData, serializeJsonLd } from '$lib/services/seo/structured-data';
 import { error } from '@sveltejs/kit';
 
 export async function load({ params, platform, url }) {
@@ -16,5 +17,8 @@ export async function load({ params, platform, url }) {
 		});
 	}
 
-	return post;
+	return {
+		...post,
+		articleStructuredDataJson: serializeJsonLd(buildArticleStructuredData(post))
+	};
 }

--- a/src/routes/thoughts/[slug]/+page.svelte
+++ b/src/routes/thoughts/[slug]/+page.svelte
@@ -2,6 +2,7 @@
 	import { invalidateAll } from '$app/navigation';
 	import Container from '$lib/atoms/container/Container.svelte';
 	import ContentfulRichText from '$lib/organisms/rich_text/ContentfulRichText.svelte';
+	import JsonLd from '$lib/services/seo/JsonLd.svelte';
 	import OpenGraphHead from '$lib/services/seo/OpenGraphHead.svelte';
 	import { buildOpenGraphMetadata } from '$lib/services/seo/open-graph';
 	import { ContentfulLivePreview } from '@contentful/live-preview';
@@ -19,6 +20,9 @@
 			} | null;
 			body: { nodeType: string; content: unknown[] } | null;
 			tags: string[];
+			published: string;
+			lastUpdated: string;
+			articleStructuredDataJson: string;
 			contentfulMetadata: {
 				entryId: string;
 				locale: string;
@@ -86,6 +90,8 @@
 </script>
 
 <OpenGraphHead {metadata} />
+
+<JsonLd json={data.articleStructuredDataJson} />
 
 <main class="thought-post">
 	<Container maxWidth="narrow">


### PR DESCRIPTION
## Summary
- Add reusable JSON-LD builders for `WebSite`, `Person`, and blog `Article` schema.
- Emit site-wide structured data from the app shell and article schema from `/thoughts/[slug]` pages.
- Add Contentful `blogPost.description` support with a rich-text fallback, plus publish/update timestamps for structured data.
- Document the structured data approach and add the Contentful migration for the new blog post field.

## Testing
- `npm run check` passed.
- `npm run lint:code` passed.
- `npm run lint:docs` passed.
- `prettier --check` passed for the changed files.
- `npm run build` passed.
- `npm run test:unit` passed.
- `npm run security` could not complete locally because `osv-scanner`, `gitleaks`, and `semgrep` are not installed.