### PR TITLE
Add Dependabot updates for GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -27,3 +27,13 @@ updates:
         patterns:
           - 'vitest'
           - '@vitest/*'
+  - package-ecosystem: 'github-actions'
+    directory: '/'
+    schedule:
+      interval: 'weekly'
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: 'chore(deps)'
+    labels:
+      - 'dependencies'
+      - 'github-actions'

--- a/README.md
+++ b/README.md
@@ -219,6 +219,7 @@ Before handing a branch over for review or merge, run `npm run check`, `npm run 
 
 ## GitHub automation
 
+- `.github/dependabot.yml` checks npm packages and GitHub Actions weekly, opening dependency PRs with `chore(deps)` commits.
 - `.github/workflows/ci.yml` runs the OSS validation pipeline on pull requests and pushes to `main`.
 - `.github/workflows/security.yml` runs a scheduled weekly security scan and supports manual dispatch.
 - `.github/workflows/contentful-migrations.yml` validates and applies Contentful migrations, and now follows the same Node runtime baseline as the rest of the repo.


### PR DESCRIPTION
## Summary
- Add a Dependabot update entry for `github-actions` so workflow dependencies are checked weekly
- Keep dependency PRs labeled and committed consistently with the existing npm updates
- Document the Dependabot coverage in `README.md`

## Testing
- `npm run check` passed
- `npx prettier --check .github/dependabot.yml README.md` passed
- `npm run lint` was not fully green because the repo has existing broader Prettier drift outside this change
- `npm run security` could not complete because `osv-scanner` is not installed in the local PATH