### PR TITLE
Add a `security.txt` well-known policy file

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,6 +215,7 @@ Before handing a branch over for review or merge, run `npm run check`, `npm run 
 - `src/hooks.server.ts` blocks high-volume probe paths (`*.php`, `/wp-*`, and `/xmlrpc.php`) early in the request lifecycle with a low-information `404 Not Found` response, and emits sampled warning logs with request metadata for observability.
 - `src/routes/robots.txt/+server.ts` serves crawler guidance dynamically: only the canonical production origin `https://www.chrisipowell.co.uk` allows crawling and advertises the sitemap, while preview, branch, staging, and local origins return `Disallow: /`.
 - `src/routes/sitemap.xml/+server.ts` serves a canonical XML sitemap built from first-class public routes plus published Contentful pages and blog posts, with 24-hour edge-friendly caching. When a new public route or indexable content type launches, update `src/lib/services/seo/sitemap.ts` in the same change so it stays discoverable.
+- `static/.well-known/security.txt` publishes the security contact policy at `/.well-known/security.txt`. Keep its `Expires` value within one year whenever the file is refreshed.
 - Open Graph metadata uses the same canonical production origin, strips query strings/trailing slashes, includes the `Chris I Powell` site name in titles, and defaults to `static/logo-cip.png` when a page-specific image is unavailable.
 
 ## GitHub automation

--- a/static/.well-known/security.txt
+++ b/static/.well-known/security.txt
@@ -1,4 +1,4 @@
-Contact: mailto:hello@cipowell.com
+Contact: mailto:security@chrisipowell.co.uk
 Expires: 2027-05-02T00:00:00.000Z
 Preferred-Languages: en
 Canonical: https://www.chrisipowell.co.uk/.well-known/security.txt

--- a/static/.well-known/security.txt
+++ b/static/.well-known/security.txt
@@ -1,0 +1,4 @@
+Contact: mailto:hello@cipowell.com
+Expires: 2027-05-02T00:00:00.000Z
+Preferred-Languages: en
+Canonical: https://www.chrisipowell.co.uk/.well-known/security.txt


### PR DESCRIPTION
## Summary
- Add `/.well-known/security.txt` as a static site asset so security contact details are served from the standard well-known location.
- Document the new file in `README.md` and note that the `Expires` value should stay within one year when refreshed.

## Testing
- `npm run check` passed.
- `npm run build` passed and confirmed the asset is emitted into the SvelteKit output.
- `npx prettier --check README.md` passed.
- `npx markdownlint-cli2 README.md` passed.