### PR TITLE
[codex] fix library preview inspector

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Component-scoped styles should live in colocated `*.module.css` files rather tha
 - **SvelteKit app shell**: `+layout.svelte` renders `Header`, `Nav`, page content, and footer.
 - **Service layer**: navigation/page clients are abstracted behind small interfaces in `src/lib/services/**`.
 - **Content source**: Contentful is the backing CMS for page content and nav links.
-- **Library route**: `src/routes/library/+page.svelte` renders a curated bookshelf-style library from local seed data in `src/lib/services/library/library.ts`.
+- **Library route**: `src/routes/library/+page.svelte` renders a curated bookshelf-style library from Contentful `libraryEntry` content, with local seed data fallback when Contentful credentials are unavailable outside preview mode.
 - **SEO metadata**: public routes use `src/lib/services/seo/open-graph.ts` and `OpenGraphHead.svelte` for canonical Open Graph tags. See `docs/seo.md` before adding new public pages or content types.
 - **Component library**: atoms/molecules/organisms live in `src/lib/**` with Storybook stories and docs.
 - **Cloudflare target**: adapter is `@sveltejs/adapter-cloudflare` and Worker config is in `wrangler.toml`.
@@ -73,6 +73,8 @@ cp .env.example .env
 
 ```bash
 CONTENTFUL_API_KEY=<your_contentful_delivery_or_preview_token>
+# Optional, used for ?preview=true draft content:
+CONTENTFUL_PREVIEW_API_KEY=<your_contentful_preview_token>
 # Optional, defaults to cdn.contentful.com:
 CONTENTFUL_HOST=cdn.contentful.com
 # Optional, defaults to master:
@@ -81,11 +83,10 @@ CONTENTFUL_ENVIRONMENT=master
 
 > Notes:
 >
-> - Preview environment uses `preview.contentful.com` via `wrangler.toml`.
-> - Preview API mode now activates only when requests originate from Contentful Live Preview (Contentful app iframe context), not via URL query flags.
+> - Preview API mode activates with `?preview=true` and uses `preview.contentful.com`.
 > - If `CONTENTFUL_ENVIRONMENT` is not set, the app defaults Contentful environment to `master`.
-> - The Contentful Live Preview SDK is loaded only when the page is embedded in Contentful Live Preview.
-> - If `CONTENTFUL_API_KEY` is missing, server-side page and nav fetches will fail.
+> - The Contentful Live Preview SDK is loaded when `?preview=true` is present.
+> - If `CONTENTFUL_API_KEY` is missing, server-side Contentful page fetches fail; `/library` and `/library/[slug]` fall back to seed content outside preview mode so local UI work can continue.
 
 1. (Only needed once per machine) install Playwright browsers:
 

--- a/docs/library-bookshelf-experience.md
+++ b/docs/library-bookshelf-experience.md
@@ -20,7 +20,7 @@
 
 - Use warm paper and timber tokens from [`src/lib/main.css`](../src/lib/main.css) to create the bookshelf feel.
 - Keep shared site tokens intact; route-specific background shifts for `/library` should be applied in the library CSS module rather than by changing the global `--color-background` token.
-- Keep the layout open and aligned with the rest of the site: rely on spacing, rules, and typography more than boxed panels or heavily rounded containers.
+- Keep the layout open and aligned with the rest of the site: rely on negative space and typography more than boxed panels, section borders, or heavily rounded containers.
 - Keep cards editorial and tactile without decorative left-edge color flashes, shelf rails, or circular icon badges. The distinction between books and articles should come from the Lucide icon and type label instead.
 - Preserve the site's existing typography so the new page feels like part of the same system instead of a separate microsite.
 
@@ -30,7 +30,9 @@
 - Tablet and up: the stat cards move into a three-column row and the reading grid expands to two and then three columns.
 - Topic and type filters remain visible near the top of the page so the core interaction stays reachable after the hero.
 
-## Content Source
+## Content Source and Preview
 
-- The initial version is seeded from [`src/lib/services/library/library.ts`](../src/lib/services/library/library.ts).
-- This avoids introducing a Contentful model before the information architecture is settled, while still giving later CMS work a concrete UI target.
+- Library content is loaded from the `libraryEntry` Contentful model and mapped through [`src/lib/services/library/library.ts`](../src/lib/services/library/library.ts).
+- `/library` and `/library/[slug]` both support Contentful preview mode via `?preview=true`.
+- Library cards and detail-page fields include Contentful inspector tags for the editable fields they render.
+- Outside preview mode, Library routes fall back to local seed content when Contentful credentials are missing so local UI work does not render the site error page.

--- a/docs/library-information-architecture.md
+++ b/docs/library-information-architecture.md
@@ -52,7 +52,7 @@ That makes Library adjacent to Thoughts, but not a sub-section of it. Thoughts i
 
 ### Launch grouping
 
-At launch, the landing page should surface separate `Books` and `Articles` sections within `/library`, rather than creating separate top-level collection routes immediately.
+At launch, the landing page should surface one mixed collection that can be filtered by `Books`, `Articles`, and topic, rather than creating separate top-level collection routes immediately.
 
 ### Future-safe extensions
 

--- a/src/lib/organisms/library_experience/LibraryExperience.module.css
+++ b/src/lib/organisms/library_experience/LibraryExperience.module.css
@@ -5,7 +5,7 @@
 
 .layout {
 	display: grid;
-	gap: var(--space-4);
+	gap: var(--space-5);
 }
 
 .hero,
@@ -120,7 +120,7 @@
 
 .collection {
 	display: grid;
-	gap: var(--space-2);
+	gap: var(--space-3);
 }
 
 .collectionHeader {
@@ -134,7 +134,6 @@
 
 .empty {
 	padding-top: var(--space-2);
-	border-top: 1px solid var(--color-library-rule);
 }
 
 .empty h2 {

--- a/src/lib/organisms/library_experience/LibraryExperience.svelte
+++ b/src/lib/organisms/library_experience/LibraryExperience.svelte
@@ -1,9 +1,16 @@
 <script lang="ts">
+	import { invalidateAll } from '$app/navigation';
 	import Container from '$lib/atoms/container/Container.svelte';
 	import LibraryShelf from '$lib/organisms/library_shelf/LibraryShelf.svelte';
-	import type { LibraryEntryType, LibraryShelfEntry } from '$lib/services/library/library';
+	import type {
+		LibraryEntryType,
+		LibraryLivePreviewState,
+		LibraryShelfEntry
+	} from '$lib/services/library/library';
 	import OpenGraphHead from '$lib/services/seo/OpenGraphHead.svelte';
 	import { buildOpenGraphMetadata } from '$lib/services/seo/open-graph';
+	import { ContentfulLivePreview } from '@contentful/live-preview';
+	import { onMount } from 'svelte';
 	import styles from './LibraryExperience.module.css';
 
 	interface Props {
@@ -13,9 +20,10 @@
 			books: number;
 			articles: number;
 		};
+		livePreview: LibraryLivePreviewState;
 	}
 
-	let { entries, topics, counts }: Props = $props();
+	let { entries, topics, counts, livePreview }: Props = $props();
 	let activeTopic = $state('all');
 	let activeTypes = $state<LibraryEntryType[]>(['book', 'article']);
 	const description =
@@ -82,6 +90,48 @@
 	const resultSummary = $derived(
 		`${filteredEntries.length} pick${filteredEntries.length === 1 ? '' : 's'} showing ${filteredBooks.length} book${filteredBooks.length === 1 ? '' : 's'} and ${filteredArticles.length} article${filteredArticles.length === 1 ? '' : 's'}`
 	);
+
+	onMount(() => {
+		if (!livePreview.enabled) {
+			return;
+		}
+
+		let unsubscribe: (() => void) | undefined;
+		let cancelled = false;
+		let refreshInFlight = false;
+
+		const subscribeAfterInit = async () => {
+			while (!ContentfulLivePreview.initialized && !cancelled) {
+				await new Promise((resolve) => setTimeout(resolve, 50));
+			}
+
+			if (cancelled) {
+				return;
+			}
+
+			unsubscribe = ContentfulLivePreview.subscribe('save', {
+				callback: async () => {
+					if (refreshInFlight) {
+						return;
+					}
+
+					refreshInFlight = true;
+					try {
+						await invalidateAll();
+					} finally {
+						refreshInFlight = false;
+					}
+				}
+			});
+		};
+
+		void subscribeAfterInit();
+
+		return () => {
+			cancelled = true;
+			unsubscribe?.();
+		};
+	});
 </script>
 
 <OpenGraphHead {metadata} />

--- a/src/lib/organisms/library_shelf/LibraryShelf.module.css
+++ b/src/lib/organisms/library_shelf/LibraryShelf.module.css
@@ -2,8 +2,8 @@
 	list-style: none;
 	display: grid;
 	grid-template-columns: repeat(1, minmax(0, 1fr));
-	column-gap: var(--space-3);
-	row-gap: var(--space-4);
+	column-gap: var(--space-4);
+	row-gap: var(--space-5);
 	margin: 0;
 	padding: 0;
 }
@@ -15,7 +15,6 @@
 .card {
 	display: grid;
 	height: 100%;
-	border-top: 1px solid var(--color-library-card-border);
 	background: transparent;
 }
 
@@ -98,7 +97,7 @@
 	list-style: none;
 	display: flex;
 	flex-wrap: wrap;
-	column-gap: 0.75rem;
+	column-gap: var(--space-1);
 	row-gap: 0.25rem;
 	margin: 0;
 	padding: 0;
@@ -108,31 +107,21 @@
 	color: var(--color-library-topic-text);
 	font-size: 0.85rem;
 	position: relative;
-	padding-left: 0.75rem;
 }
 
-.topics li::before {
-	content: '';
-	position: absolute;
-	left: 0;
-	top: 50%;
-	inline-size: 0.3rem;
-	block-size: 0.3rem;
-	border-radius: 999px;
-	background: var(--color-library-topic-marker);
-	transform: translateY(-50%);
+.topics li + li::before {
+	content: '/';
+	margin-right: var(--space-1);
+	color: var(--color-library-meta-divider);
 }
 
 @media (hover: hover) and (prefers-reduced-motion: no-preference) {
 	.card {
-		transition:
-			transform 180ms ease,
-			border-color 180ms ease;
+		transition: transform 180ms ease;
 	}
 
 	.card:hover {
 		transform: translateY(-0.15rem);
-		border-color: var(--color-library-card-border-strong);
 	}
 }
 

--- a/src/lib/organisms/library_shelf/LibraryShelf.svelte
+++ b/src/lib/organisms/library_shelf/LibraryShelf.svelte
@@ -2,6 +2,7 @@
 	import BookOpenText from '@lucide/svelte/icons/book-open-text';
 	import Newspaper from '@lucide/svelte/icons/newspaper';
 	import type { LibraryShelfEntry } from '$lib/services/library/library';
+	import { ContentfulLivePreview } from '@contentful/live-preview';
 	import styles from './LibraryShelf.module.css';
 
 	interface Props {
@@ -12,6 +13,21 @@
 
 	function formatTopic(topic: string) {
 		return topic.replace(/\b\w/g, (character) => character.toUpperCase());
+	}
+
+	function getInspectorProps(item: LibraryShelfEntry, fieldId: string): Record<string, string> {
+		if (!item.contentfulMetadata) {
+			return {};
+		}
+
+		return (
+			ContentfulLivePreview.getProps({
+				entryId: item.contentfulMetadata.entryId,
+				fieldId,
+				environment: item.contentfulMetadata.environment,
+				locale: item.contentfulMetadata.locale
+			}) ?? {}
+		);
 	}
 </script>
 
@@ -35,11 +51,11 @@
 					</div>
 
 					<div class={styles.copy}>
-						<h3>{item.title}</h3>
-						<p>{item.summary}</p>
+						<h3 {...getInspectorProps(item, 'title')}>{item.title}</h3>
+						<p {...getInspectorProps(item, 'summary')}>{item.summary}</p>
 					</div>
 
-					<p class={styles.creator}>{item.creator}</p>
+					<p class={styles.creator} {...getInspectorProps(item, 'creatorText')}>{item.creator}</p>
 
 					<ul class={styles.topics} aria-label={`${item.title} topics`}>
 						{#each item.topics as topic (topic)}

--- a/src/lib/services/cms/contentful.test.ts
+++ b/src/lib/services/cms/contentful.test.ts
@@ -470,6 +470,7 @@ describe('Contentful library queries', () => {
 		getEntriesMock.mockResolvedValueOnce({
 			items: [
 				{
+					sys: { id: 'library-preview-1', locale: 'en-US' },
 					fields: {
 						title: 'An Elegant Puzzle',
 						slug: 'an-elegant-puzzle',
@@ -524,6 +525,14 @@ describe('Contentful library queries', () => {
 					url: 'https://images.ctfassets.net/library/book-cover.jpg',
 					title: 'An Elegant Puzzle cover',
 					description: 'Book cover image'
+				},
+				contentfulMetadata: {
+					entryId: 'library-preview-1',
+					locale: 'en-US',
+					environment: 'master'
+				},
+				livePreview: {
+					enabled: false
 				}
 			}
 		]);

--- a/src/lib/services/cms/contentful.ts
+++ b/src/lib/services/cms/contentful.ts
@@ -416,7 +416,15 @@ class Contentful implements NavClient, PageClient {
 			startedOn: this.getDateFieldValue(entry.fields.startedOn),
 			finishedOn: this.getDateFieldValue(entry.fields.finishedOn),
 			rating: this.getIntegerFieldValue(entry.fields.rating),
-			coverImage: this.getAssetImage(entry.fields.coverOrThumbnail)
+			coverImage: this.getAssetImage(entry.fields.coverOrThumbnail),
+			contentfulMetadata: {
+				entryId: entry.sys.id,
+				locale: entry.sys.locale || 'en-US',
+				environment: this.contentfulEnvironment
+			},
+			livePreview: {
+				enabled: this.previewEnabled
+			}
 		};
 	}
 

--- a/src/lib/services/library/library.test.ts
+++ b/src/lib/services/library/library.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, test } from 'vitest';
+import { getLibraryEntryData, getLibraryPageData } from './library';
+
+describe('seed Library data', () => {
+	test('returns local fallback page data with preview disabled', () => {
+		const pageData = getLibraryPageData();
+
+		expect(pageData.entries.length).toBeGreaterThan(0);
+		expect(pageData.livePreview).toEqual({ enabled: false });
+	});
+
+	test('returns local fallback detail data for seeded entries', () => {
+		const entry = getLibraryEntryData('art-of-gathering');
+
+		expect(entry).toMatchObject({
+			title: 'The Art of Gathering',
+			slug: 'art-of-gathering',
+			format: 'book',
+			contentfulMetadata: {
+				entryId: 'art-of-gathering',
+				locale: 'en-US',
+				environment: 'local'
+			},
+			livePreview: {
+				enabled: false
+			}
+		});
+	});
+});

--- a/src/lib/services/library/library.ts
+++ b/src/lib/services/library/library.ts
@@ -12,6 +12,16 @@ export interface LibraryImage {
 	description: string;
 }
 
+interface LibraryContentfulMetadata {
+	entryId: string;
+	locale: string;
+	environment: string;
+}
+
+export interface LibraryLivePreviewState {
+	enabled: boolean;
+}
+
 export interface LibraryEntryPreview {
 	title: string;
 	slug: string;
@@ -29,18 +39,14 @@ export interface LibraryEntryPreview {
 	finishedOn: string;
 	rating: number | null;
 	coverImage: LibraryImage | null;
+	contentfulMetadata?: LibraryContentfulMetadata;
+	livePreview?: LibraryLivePreviewState;
 }
 
 export interface LibraryEntry extends LibraryEntryPreview {
 	notes: RichTextDocument | null;
-	contentfulMetadata: {
-		entryId: string;
-		locale: string;
-		environment: string;
-	};
-	livePreview: {
-		enabled: boolean;
-	};
+	contentfulMetadata: LibraryContentfulMetadata;
+	livePreview: LibraryLivePreviewState;
 }
 
 export interface LibraryShelfEntry {
@@ -52,6 +58,7 @@ export interface LibraryShelfEntry {
 	topics: string[];
 	detail: string;
 	href: string;
+	contentfulMetadata?: LibraryContentfulMetadata;
 }
 
 export interface LibraryPageData {
@@ -61,6 +68,7 @@ export interface LibraryPageData {
 		books: number;
 		articles: number;
 	};
+	livePreview: LibraryLivePreviewState;
 }
 
 function cloneTopics(topics: string[]): string[] {
@@ -138,7 +146,8 @@ function mapLibraryPreviewToShelfEntry(entry: LibraryEntryPreview): LibraryShelf
 		type: entry.format,
 		topics: cloneTopics(entry.topics),
 		detail: getLibraryEntryDetail(entry),
-		href: `/library/${entry.slug}`
+		href: `/library/${entry.slug}`,
+		contentfulMetadata: entry.contentfulMetadata
 	};
 }
 
@@ -148,7 +157,10 @@ export function createLibraryPageData(previewEntries: LibraryEntryPreview[]): Li
 	return {
 		entries,
 		topics: getLibraryTopics(entries),
-		counts: countEntries(entries)
+		counts: countEntries(entries),
+		livePreview: {
+			enabled: previewEntries.some((entry) => entry.livePreview?.enabled)
+		}
 	};
 }
 
@@ -256,6 +268,45 @@ export function getLibraryPageData(): LibraryPageData {
 	return {
 		entries,
 		topics: getLibraryTopics(entries),
-		counts: countEntries(entries)
+		counts: countEntries(entries),
+		livePreview: {
+			enabled: false
+		}
+	};
+}
+
+export function getLibraryEntryData(slug: string): LibraryEntry {
+	const entry = getSeedLibraryEntries().find((item) => item.id === slug);
+
+	if (!entry) {
+		throw new Error(`Library entry not found: ${slug}`);
+	}
+
+	return {
+		title: entry.title,
+		slug: entry.id,
+		format: entry.type,
+		creatorText: entry.creator,
+		summary: entry.summary,
+		recommendationNote: entry.summary,
+		miniReview: '',
+		publicationTitle: entry.type === 'article' ? entry.creator : '',
+		publicationDate: '',
+		externalUrl: '',
+		topics: cloneTopics(entry.topics),
+		readingStatus: '',
+		startedOn: '',
+		finishedOn: '',
+		rating: null,
+		coverImage: null,
+		notes: null,
+		contentfulMetadata: {
+			entryId: entry.id,
+			locale: 'en-US',
+			environment: 'local'
+		},
+		livePreview: {
+			enabled: false
+		}
 	};
 }

--- a/src/routes/library/+page.server.ts
+++ b/src/routes/library/+page.server.ts
@@ -1,9 +1,19 @@
 import Contentful from '$lib/services/cms/contentful';
-import { createLibraryPageData } from '$lib/services/library/library';
+import { createLibraryPageData, getLibraryPageData } from '$lib/services/library/library';
 
 export async function load({ platform, url }) {
 	const preview = url.searchParams.get('preview') === 'true';
-	const contentful = new Contentful(platform, preview);
-	const entries = await contentful.getLibraryEntries();
-	return createLibraryPageData(entries);
+
+	try {
+		const contentful = new Contentful(platform, preview);
+		const entries = await contentful.getLibraryEntries();
+		return createLibraryPageData(entries);
+	} catch (err) {
+		if (preview) {
+			throw err;
+		}
+
+		console.warn('Falling back to seeded Library content for local development.', err);
+		return getLibraryPageData();
+	}
 }

--- a/src/routes/library/+page.svelte
+++ b/src/routes/library/+page.svelte
@@ -9,4 +9,9 @@
 	let { data }: Props = $props();
 </script>
 
-<LibraryExperience entries={data.entries} topics={data.topics} counts={data.counts} />
+<LibraryExperience
+	entries={data.entries}
+	topics={data.topics}
+	counts={data.counts}
+	livePreview={data.livePreview}
+/>

--- a/src/routes/library/[slug]/+page.server.ts
+++ b/src/routes/library/[slug]/+page.server.ts
@@ -1,15 +1,24 @@
-import type { LibraryEntry } from '$lib/services/library/library';
+import { getLibraryEntryData, type LibraryEntry } from '$lib/services/library/library';
 import Contentful from '$lib/services/cms/contentful';
 import { error } from '@sveltejs/kit';
 
 export async function load({ params, platform, url }) {
 	const preview = url.searchParams.get('preview') === 'true';
-	const contentful = new Contentful(platform, preview);
 	let entry: LibraryEntry;
 
 	try {
+		const contentful = new Contentful(platform, preview);
 		entry = await contentful.getLibraryEntry(params.slug);
 	} catch (err) {
+		if (!preview) {
+			try {
+				console.warn('Falling back to seeded Library entry for local development.', err);
+				return getLibraryEntryData(params.slug);
+			} catch {
+				// Continue to the shared 404 below.
+			}
+		}
+
 		console.error(err);
 		throw error(404, {
 			message: 'Library entry not found'

--- a/src/routes/library/[slug]/+page.svelte
+++ b/src/routes/library/[slug]/+page.svelte
@@ -6,6 +6,7 @@
 	import { buildOpenGraphMetadata } from '$lib/services/seo/open-graph';
 	import { ContentfulLivePreview } from '@contentful/live-preview';
 	import { onMount } from 'svelte';
+	import styles from './LibraryEntryPage.module.css';
 
 	interface Props {
 		data: {
@@ -33,6 +34,7 @@
 			contentfulMetadata: {
 				entryId: string;
 				locale: string;
+				environment: string;
 			};
 			livePreview: {
 				enabled: boolean;
@@ -73,6 +75,17 @@
 			.split('-')
 			.map((part) => part.charAt(0).toUpperCase() + part.slice(1))
 			.join(' ');
+	}
+
+	function getInspectorProps(fieldId: string): Record<string, string> {
+		return (
+			ContentfulLivePreview.getProps({
+				entryId: data.contentfulMetadata.entryId,
+				fieldId,
+				environment: data.contentfulMetadata.environment,
+				locale: data.contentfulMetadata.locale
+			}) ?? {}
+		);
 	}
 
 	onMount(() => {
@@ -120,47 +133,47 @@
 
 <OpenGraphHead {metadata} />
 
-<main class="library-entry-page">
+<main class={styles.page}>
 	<Container maxWidth="narrow">
-		<article class="library-entry" data-contentful-entry-id={data.contentfulMetadata.entryId}>
-			<a class="library-entry__back-link" href="/library">Back to library</a>
+		<article class={styles.entry}>
+			<a class={styles.backLink} href="/library">Back to library</a>
 
-			<div class="library-entry__hero">
+			<div class={styles.hero}>
 				{#if data.coverImage}
 					<img
-						class="library-entry__cover"
+						class={styles.cover}
 						src={data.coverImage.url}
 						alt={data.coverImage.description || `${data.title} cover image`}
+						{...getInspectorProps('coverOrThumbnail')}
 					/>
 				{/if}
 
-				<div class="library-entry__hero-copy">
-					<p class="library-entry__eyebrow">{data.format === 'book' ? 'Book' : 'Article'}</p>
-					<h1
-						data-contentful-field-id="title"
-						data-contentful-locale={data.contentfulMetadata.locale}
-					>
+				<div class={styles.heroCopy}>
+					<p class={styles.eyebrow}>{data.format === 'book' ? 'Book' : 'Article'}</p>
+					<h1 {...getInspectorProps('title')}>
 						{data.title}
 					</h1>
-					<p class="library-entry__creator">{data.creatorText}</p>
+					<p class={styles.creator} {...getInspectorProps('creatorText')}>{data.creatorText}</p>
 
-					<ul class="library-entry__meta" aria-label="Library entry metadata">
+					<ul class={styles.meta} aria-label="Library entry metadata">
 						{#if data.publicationTitle}
-							<li>{data.publicationTitle}</li>
+							<li {...getInspectorProps('publicationTitle')}>{data.publicationTitle}</li>
 						{/if}
 						{#if data.publicationDate}
-							<li>{formatDate(data.publicationDate)}</li>
+							<li {...getInspectorProps('publicationDate')}>{formatDate(data.publicationDate)}</li>
 						{/if}
 						{#if data.readingStatus}
-							<li>{formatReadingStatus(data.readingStatus)}</li>
+							<li {...getInspectorProps('readingStatus')}>
+								{formatReadingStatus(data.readingStatus)}
+							</li>
 						{/if}
 						{#if data.rating}
-							<li>{data.rating}/5</li>
+							<li {...getInspectorProps('rating')}>{data.rating}/5</li>
 						{/if}
 					</ul>
 
 					{#if data.topics.length}
-						<ul class="library-entry__topics" aria-label="Library topics">
+						<ul class={styles.topics} aria-label="Library topics" {...getInspectorProps('topics')}>
 							{#each data.topics as topic (topic)}
 								<li>{topic}</li>
 							{/each}
@@ -169,174 +182,66 @@
 
 					{#if data.externalUrl}
 						<p>
-							<a href={data.externalUrl} target="_blank" rel="noreferrer">Visit original source</a>
+							<a
+								href={data.externalUrl}
+								target="_blank"
+								rel="noreferrer"
+								{...getInspectorProps('externalUrl')}>Visit original source</a
+							>
 						</p>
 					{/if}
 				</div>
 			</div>
 
-			<section class="library-entry__section">
-				<p class="library-entry__section-label">Summary</p>
-				<p
-					class="library-entry__lead"
-					data-contentful-field-id="summary"
-					data-contentful-locale={data.contentfulMetadata.locale}
-				>
+			<section class={styles.section}>
+				<p class={styles.sectionLabel}>Summary</p>
+				<p class={styles.lead} {...getInspectorProps('summary')}>
 					{data.summary}
 				</p>
 			</section>
 
-			<section class="library-entry__section">
-				<p class="library-entry__section-label">Why it stays with me</p>
-				<p
-					class="library-entry__callout"
-					data-contentful-field-id="recommendationNote"
-					data-contentful-locale={data.contentfulMetadata.locale}
-				>
+			<section class={styles.section}>
+				<p class={styles.sectionLabel}>Why it stays with me</p>
+				<p class={styles.callout} {...getInspectorProps('recommendationNote')}>
 					{data.recommendationNote}
 				</p>
 			</section>
 
 			{#if data.miniReview}
-				<section class="library-entry__section">
-					<p class="library-entry__section-label">Mini review</p>
-					<p
-						data-contentful-field-id="miniReview"
-						data-contentful-locale={data.contentfulMetadata.locale}
-					>
+				<section class={styles.section}>
+					<p class={styles.sectionLabel}>Mini review</p>
+					<p {...getInspectorProps('miniReview')}>
 						{data.miniReview}
 					</p>
 				</section>
 			{/if}
 
 			{#if data.startedOn || data.finishedOn}
-				<section class="library-entry__section">
-					<p class="library-entry__section-label">Reading log</p>
-					<div class="library-entry__dates">
+				<section class={styles.section}>
+					<p class={styles.sectionLabel}>Reading log</p>
+					<div class={styles.dates}>
 						{#if data.startedOn}
-							<p><strong>Started:</strong> {formatDate(data.startedOn)}</p>
+							<p {...getInspectorProps('startedOn')}>
+								<strong>Started:</strong>
+								{formatDate(data.startedOn)}
+							</p>
 						{/if}
 						{#if data.finishedOn}
-							<p><strong>Finished:</strong> {formatDate(data.finishedOn)}</p>
+							<p {...getInspectorProps('finishedOn')}>
+								<strong>Finished:</strong>
+								{formatDate(data.finishedOn)}
+							</p>
 						{/if}
 					</div>
 				</section>
 			{/if}
 
 			{#if notes}
-				<section
-					class="library-entry__section library-entry__notes"
-					data-contentful-field-id="notes"
-					data-contentful-locale={data.contentfulMetadata.locale}
-				>
-					<p class="library-entry__section-label">Notes</p>
+				<section class={`${styles.section} ${styles.notes}`} {...getInspectorProps('notes')}>
+					<p class={styles.sectionLabel}>Notes</p>
 					<ContentfulRichText document={notes} />
 				</section>
 			{/if}
 		</article>
 	</Container>
 </main>
-
-<style>
-	.library-entry-page {
-		padding-block: var(--space-5) var(--space-7);
-	}
-
-	.library-entry {
-		display: grid;
-		gap: var(--space-4);
-	}
-
-	.library-entry__back-link {
-		font-family: var(--font-heading);
-		font-weight: var(--font-weight-medium);
-	}
-
-	.library-entry__hero {
-		display: grid;
-		gap: var(--space-3);
-		align-items: start;
-		padding: var(--space-4);
-		border: 1px solid var(--color-divider-default);
-		border-radius: var(--space-3);
-		background: var(--color-library-detail-surface);
-	}
-
-	.library-entry__cover {
-		float: none;
-		width: 100%;
-		max-height: none;
-		margin: 0;
-		border-radius: var(--space-2);
-		object-fit: cover;
-		aspect-ratio: 4 / 5;
-	}
-
-	.library-entry__hero-copy,
-	.library-entry__section {
-		display: grid;
-		gap: var(--space-2);
-	}
-
-	.library-entry__eyebrow,
-	.library-entry__section-label {
-		margin: 0;
-		font-family: var(--font-heading);
-		font-weight: var(--font-weight-medium);
-		letter-spacing: 0.06em;
-		text-transform: uppercase;
-	}
-
-	.library-entry__creator,
-	.library-entry__lead,
-	.library-entry__callout,
-	.library-entry__dates p,
-	.library-entry__section :global(p),
-	.library-entry__section :global(li),
-	.library-entry__section :global(blockquote) {
-		margin: 0;
-		font-size: var(--font-size-body-lg);
-		line-height: var(--line-height-body);
-	}
-
-	.library-entry__callout {
-		padding-left: var(--space-2);
-		border-left: 3px solid var(--color-library-note-accent);
-		font-family: var(--font-heading);
-	}
-
-	.library-entry__meta,
-	.library-entry__topics {
-		display: flex;
-		flex-wrap: wrap;
-		gap: var(--space-1);
-		margin: 0;
-		padding: 0;
-		list-style: none;
-	}
-
-	.library-entry__meta li,
-	.library-entry__topics li {
-		padding: calc(var(--space-1) * 0.75) var(--space-2);
-		border-radius: var(--space-4);
-		background: var(--color-library-filter-surface);
-	}
-
-	.library-entry__section {
-		padding: var(--space-3);
-		border: 1px solid var(--color-divider-default);
-		border-radius: var(--space-3);
-		background: var(--color-surface-default);
-	}
-
-	.library-entry__notes :global(ul),
-	.library-entry__notes :global(ol) {
-		padding-left: 1.25rem;
-	}
-
-	@media (min-width: 48rem) {
-		.library-entry__hero {
-			grid-template-columns: minmax(12rem, 16rem) minmax(0, 1fr);
-		}
-	}
-</style>

--- a/src/routes/library/[slug]/LibraryEntryPage.module.css
+++ b/src/routes/library/[slug]/LibraryEntryPage.module.css
@@ -1,0 +1,130 @@
+.page {
+	padding-block: var(--space-5) var(--space-7);
+}
+
+.entry {
+	display: grid;
+	gap: var(--space-5);
+}
+
+.backLink {
+	justify-self: start;
+	font-family: var(--font-heading);
+	font-weight: var(--font-weight-medium);
+}
+
+.hero {
+	display: grid;
+	gap: var(--space-4);
+	align-items: start;
+	padding-block: var(--space-2) var(--space-3);
+}
+
+.cover {
+	float: none;
+	width: 100%;
+	max-height: none;
+	margin: 0;
+	object-fit: cover;
+	aspect-ratio: 4 / 5;
+}
+
+.heroCopy,
+.section {
+	display: grid;
+	gap: var(--space-2);
+}
+
+.heroCopy {
+	align-content: start;
+	padding-block: var(--space-1);
+}
+
+.eyebrow,
+.sectionLabel {
+	margin: 0;
+	font-family: var(--font-heading);
+	font-weight: var(--font-weight-medium);
+	letter-spacing: 0.06em;
+	text-transform: uppercase;
+	color: var(--color-library-type-label);
+}
+
+.heroCopy h1,
+.section p,
+.section :global(p),
+.section :global(li),
+.section :global(blockquote),
+.creator,
+.lead,
+.callout,
+.dates p {
+	margin: 0;
+}
+
+.creator,
+.lead,
+.callout,
+.dates p,
+.section :global(p),
+.section :global(li),
+.section :global(blockquote) {
+	font-size: var(--font-size-body-lg);
+	line-height: var(--line-height-body);
+}
+
+.creator {
+	color: var(--color-library-panel-muted);
+	font-weight: var(--font-weight-medium);
+}
+
+.callout {
+	padding-left: var(--space-2);
+	border-left: 3px solid var(--color-library-note-accent);
+	font-family: var(--font-heading);
+}
+
+.meta,
+.topics {
+	display: flex;
+	flex-wrap: wrap;
+	column-gap: var(--space-2);
+	row-gap: var(--space-1);
+	margin: 0;
+	padding: 0;
+	list-style: none;
+	color: var(--color-library-card-meta);
+}
+
+.topics {
+	color: var(--color-library-topic-text);
+}
+
+.meta li,
+.topics li {
+	display: inline-flex;
+	align-items: baseline;
+	gap: var(--space-1);
+}
+
+.meta li + li::before,
+.topics li + li::before {
+	content: '/';
+	color: var(--color-library-meta-divider);
+}
+
+.section {
+	max-inline-size: 44rem;
+}
+
+.notes :global(ul),
+.notes :global(ol) {
+	padding-left: var(--rich-text-list-indent);
+}
+
+@media (min-width: 48rem) {
+	.hero {
+		grid-template-columns: minmax(12rem, 16rem) minmax(0, 1fr);
+		column-gap: var(--space-5);
+	}
+}


### PR DESCRIPTION
## Summary

- Fix Contentful Live Preview and inspector support for Library landing/detail pages by carrying Contentful metadata into Library cards, subscribing `/library` to preview save events, and tagging editable rendered fields with `ContentfulLivePreview.getProps()`.
- Add local seed-data fallbacks for `/library` and `/library/[slug]` when Contentful credentials are missing outside preview mode, so local UI work does not render the generic error page.
- Move the Library detail page styling into a CSS module and open up the Library visual treatment by relying on spacing and typography instead of boxed rounded sections.
- Update README and Library docs to reflect the Contentful-backed Library flow, preview mode, and local fallback behavior.

## Root cause

The Library landing page fetched preview content but did not subscribe to Contentful save events or pass Contentful metadata through to rendered shelf cards. The detail page had partial inspector attributes, but they were not consistently emitted via the SDK helper. Local development also failed outright when `CONTENTFUL_API_KEY` was unavailable because the Library routes constructed the Contentful client unconditionally.

## Validation

- `npm run check`
- `npm run lint:code`
- `npm run lint:docs`
- Targeted Prettier check for touched files
- `npm run test:unit -- src/lib/services/library/library.test.ts src/lib/services/cms/contentful.test.ts src/lib/organisms/library_experience/LibraryExperience.test.ts`
- In-app browser smoke check for `http://127.0.0.1:5173/library` and `http://127.0.0.1:5173/library/art-of-gathering`

## Notes

- Full `npm run lint` is still blocked by existing repo-wide Prettier drift outside this patch.
- Full `npm run security` is blocked locally because `osv-scanner`, `gitleaks`, and `semgrep` are not installed on PATH.